### PR TITLE
feat(quick): Make gateway MCP tools consumable by Amazon Quick

### DIFF
--- a/scripts/lib/commands.sh
+++ b/scripts/lib/commands.sh
@@ -569,6 +569,19 @@ _configure_prompts() {
   _answers_set OBSERVABILITY_LOG_RETENTION_DAYS "$log_retention"
   _answers_set GATEWAY_AUTH "$gateway_auth"
 
+  # JWT claim is only meaningful for the oauth authorizer. Ask only when oauth
+  # is selected; otherwise leave it untouched so iam/full deployments never see
+  # the prompt and the stored value (if any) is preserved. Default "client" is
+  # the Quick-friendly choice (access tokens carry client_id, not aud); AG-UI/
+  # ID-token callers should pick "audience".
+  if [ "$gateway_auth" = "oauth" ]; then
+    local jwt_validation_claim
+    shared_config_prompt jwt_validation_claim \
+      "JWT validation claim (client=Quick access tokens / audience=AG-UI ID tokens)" \
+      "$(shared_config_get GATEWAY_JWT_VALIDATION_CLAIM client)"
+    _answers_set GATEWAY_JWT_VALIDATION_CLAIM "$jwt_validation_claim"
+  fi
+
   # -------------------------------------------------------------------------
   # MODELS — shared deployment policy. Per-agent overrides in hierarchy.json
   # still win at runtime; this just sets the default.

--- a/scripts/lib/shared_config.sh
+++ b/scripts/lib/shared_config.sh
@@ -237,6 +237,9 @@ _ANSWER_TO_TFVAR = {
     "MODEL_DEFAULT_ID":                      "bedrock_model_id",
     "MODEL_HEALTH_ENRICHMENT_ID":            "health_enrichment_model_id",
     "CROSS_ACCOUNT_HEALTH_ROLE_ARN":         "health_events_cross_account_role_arn",
+    # Imported from SSM as GATEWAY_JWT_VALIDATION_CLAIM (path gateway/jwt_validation_claim);
+    # Terraform expects the root var name jwt_validation_claim.
+    "GATEWAY_JWT_VALIDATION_CLAIM":          "jwt_validation_claim",
 }
 for ans_key, tf_key in _ANSWER_TO_TFVAR.items():
     if ans_key in answers:

--- a/src/lambda/mcp/tag-governance/handler.py
+++ b/src/lambda/mcp/tag-governance/handler.py
@@ -1088,9 +1088,37 @@ def handle_get_remediation_guidance(event: dict[str, Any]) -> dict[str, Any]:
     full scan, small regardless of account size). Falls back to
     ``non_compliant_resources`` (per-resource, may be truncated by
     check_tag_compliance's max_resources cap) for backwards compatibility.
+
+    Self-contained fallback: if NEITHER ``remediation_buckets`` NOR
+    ``non_compliant_resources`` is supplied, this tool runs
+    check_tag_compliance internally (passing the same event through, so
+    required_tags / use_aws_evaluation / resource_types / regions all apply)
+    and uses the buckets it produces. This lets a planner that can't thread a
+    prior tool's JSON output back in (e.g. Amazon Quick) call
+    get_remediation_guidance standalone. Mirrors assess_dx_resiliency, which
+    fetches its own topology when none is passed.
     """
     scan_method = event.get("scan_method", "resource_explorer")
     max_links = max(1, int(event.get("max_links", 20)))
+
+    # Self-contained fallback: no buckets AND no per-resource list → run the
+    # compliance scan ourselves to regenerate buckets. The internal scan must
+    # finish within the caller's invocation timeout; for normally-sized
+    # accounts this is well under the limit.
+    if not event.get("remediation_buckets") and not event.get("non_compliant_resources"):
+        compliance = handle_check_tag_compliance(event)
+        # Propagate non-success responses verbatim (no policy, RE not indexed,
+        # payer-only errors) so the caller sees the actionable hint, not an
+        # empty link list.
+        if compliance.get("error") or compliance.get("status") not in (None, "ok"):
+            return compliance
+        event = {
+            **event,
+            "remediation_buckets": compliance.get("remediation_buckets", []),
+            # Use the scan's actual method so the invalid_value caveat is correct.
+            "scan_method": compliance.get("scan_method", scan_method),
+        }
+        scan_method = event["scan_method"]
 
     # Prefer pre-aggregated buckets — they reflect the full scan, not a
     # truncated sample. Fall back to reconstructing from non_compliant_resources

--- a/src/lambda/mcp/tools.json
+++ b/src/lambda/mcp/tools.json
@@ -16,7 +16,7 @@
         "tools": [
             {
                 "name": "get_cost_and_usage",
-                "description": "Retrieve AWS cost and usage data with optional filtering and grouping. Returns cost breakdown by time period with grand total. Use get_today_date first to determine correct date ranges.",
+                "description": "Retrieve AWS cost and usage data with optional filtering and grouping. Returns cost breakdown by time period with grand total. Use get_today_date first to determine correct date ranges. Use the MINIMUM calls needed: for a simple spend question, ONE monthly call with no group_by. Add group_by (SERVICE/REGION) only for a breakdown; use DAILY only for trends. Call get_today_date first to ground relative dates. Do not run extra queries the user didn't ask for.",
                 "input_schema": {
                     "type": "object",
                     "properties": {
@@ -48,7 +48,61 @@
                         },
                         "filter": {
                             "type": "object",
-                            "description": "Cost Explorer filter expression (optional)"
+                            "description": "Cost Explorer filter Expression (optional). A nested boolean of Dimensions/Tags/CostCategories with And/Or/Not. Example: {\"Dimensions\": {\"Key\": \"SERVICE\", \"Values\": [\"Amazon Elastic Compute Cloud - Compute\"]}}. Common keys: SERVICE, REGION, LINKED_ACCOUNT, USAGE_TYPE, RECORD_TYPE.",
+                            "properties": {
+                                "Dimensions": {
+                                    "type": "object",
+                                    "description": "Filter by a dimension.",
+                                    "properties": {
+                                        "Key": {
+                                            "type": "string",
+                                            "description": "e.g. SERVICE, REGION, LINKED_ACCOUNT, USAGE_TYPE"
+                                        },
+                                        "Values": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "Tags": {
+                                    "type": "object",
+                                    "description": "Filter by a cost-allocation tag.",
+                                    "properties": {
+                                        "Key": {
+                                            "type": "string"
+                                        },
+                                        "Values": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "And": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {}
+                                    },
+                                    "description": "AND of sub-expressions."
+                                },
+                                "Or": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {}
+                                    },
+                                    "description": "OR of sub-expressions."
+                                },
+                                "Not": {
+                                    "type": "object",
+                                    "description": "Negated sub-expression.",
+                                    "properties": {}
+                                }
+                            }
                         }
                     },
                     "required": [
@@ -205,7 +259,7 @@
         "tools": [
             {
                 "name": "start_query_execution",
-                "description": "Execute a SQL query on CUR (Cost and Usage Report) data via Athena. Use 'cur_data' as the table name \u2014 it is auto-substituted with the configured CUR table. Always include partition filters (year, month) for performance. Returns query results synchronously (waits for completion).",
+                "description": "Execute SQL on CUR (Cost and Usage Report) 2.0 data via Athena. Use 'cur_data' as the table name (auto-substituted). ALWAYS include partition filters for performance: billing_period = 'YYYY-MM' is the ONLY partition column (string). Date columns are TIMESTAMP type \u2014 use date_format(bill_billing_period_start_date, '%Y-%m') = 'YYYY-MM' for monthly, or line_item_usage_start_date >= TIMESTAMP 'YYYY-MM-DD HH:MM:SS' for daily. NEVER use LIMIT (use max_results). Key fields: line_item_unblended_cost, line_item_usage_account_id, line_item_product_code, line_item_line_item_type, line_item_resource_id, resource_tags (cost-allocation tags: element_at(resource_tags, 'user_<tag>')). For amortized cost, CASE on line_item_line_item_type: SavingsPlanCoveredUsage -> savings_plan_savings_plan_effective_cost; DiscountedUsage -> reservation_effective_cost; RIFee -> reservation_unused_amortized_upfront_fee_for_billing_period + reservation_unused_recurring_fee; else line_item_unblended_cost. Exclude Marketplace with bill_billing_entity = 'AWS'; exclude Tax/Credit/Refund via line_item_line_item_type NOT IN (...).",
                 "input_schema": {
                     "type": "object",
                     "properties": {
@@ -592,7 +646,21 @@
                         },
                         "filters": {
                             "type": "object",
-                            "description": "Key-value filters (e.g., {\"regionCode\": \"us-east-1\", \"instanceType\": \"m5.xlarge\", \"operatingSystem\": \"Linux\"})"
+                            "description": "Key-value attribute filters as a flat {string: string} map. Common keys shown below; any AWS pricing attribute is accepted. Example: {\"regionCode\": \"us-east-1\", \"instanceType\": \"m5.xlarge\", \"operatingSystem\": \"Linux\"}.",
+                            "properties": {
+                                "regionCode": {
+                                    "type": "string",
+                                    "description": "e.g. us-east-1"
+                                },
+                                "instanceType": {
+                                    "type": "string",
+                                    "description": "e.g. m5.xlarge"
+                                },
+                                "operatingSystem": {
+                                    "type": "string",
+                                    "description": "e.g. Linux, Windows"
+                                }
+                            }
                         },
                         "max_results": {
                             "type": "integer",
@@ -684,7 +752,7 @@
             },
             {
                 "name": "discover_dx_topology",
-                "description": "Discover the caller's AWS Direct Connect topology across all reachable regions. Returns a TopologyData JSON (DX connections, virtual interfaces, DX gateways, Transit Gateways, VPCs, VPNs, Cloud WAN) plus a fetchErrors list describing any partial API failures. Idempotent within a conversation \u2014 call ONCE per session unless the user explicitly asks to refresh.",
+                "description": "Discover the caller's AWS Direct Connect topology across all reachable regions. Returns a TopologyData JSON (DX connections, virtual interfaces, DX gateways, Transit Gateways, VPCs, VPNs, Cloud WAN) plus a fetchErrors list describing any partial API failures. Idempotent within a conversation \u2014 call ONCE per session unless the user explicitly asks to refresh. For a credential-free demo, pass mock_scenario (noResiliency | devTest | high | maximum | crossAccount | cloudWan) to return a fixture topology instantly.",
                 "input_schema": {
                     "type": "object",
                     "properties": {
@@ -701,17 +769,19 @@
             },
             {
                 "name": "assess_dx_resiliency",
-                "description": "Run the 5 resiliency rules + 17 best-practice checks + 2 SLA-precondition attestations against a topology. Returns {topology, assessment} \u2014 the topology that was assessed PLUS the CombinedAssessment (perDxGateway, global, resiliency, bestPractice). The visualizer uses both. If topology is not passed, the tool fetches it first. Call after discover_dx_topology (or instead of it) when the user asks about resiliency, best practices, or recommendations.",
+                "description": "Run the 5 resiliency rules + 17 best-practice checks + 2 SLA-precondition attestations against a topology. Returns {topology, assessment} \u2014 the topology that was assessed PLUS the CombinedAssessment (perDxGateway, global, resiliency, bestPractice). The visualizer uses both. If topology is not passed, the tool fetches it first. Call after discover_dx_topology (or instead of it) when the user asks about resiliency, best practices, or recommendations. Resiliency is reported PER DX GATEWAY as a tier (none/devtest/high/maximum) \u2014 there is NO single account-wide score; never invent one. Self-contained: omit topology to fetch live, or pass mock_scenario for a deterministic demo. NEVER fabricate SLA %, tier names, or BGP limits.",
                 "input_schema": {
                     "type": "object",
                     "properties": {
                         "topology": {
                             "type": "object",
-                            "description": "Optional TopologyData (as returned by discover_dx_topology). Omit to fetch live or pass mock_scenario."
+                            "description": "Optional TopologyData (as returned by discover_dx_topology). Omit to fetch live or pass mock_scenario.",
+                            "properties": {}
                         },
                         "targets": {
                             "type": "object",
-                            "description": "Target tier. Pass a string 'high' or 'maximum' to apply to every DXGW, OR an object keyed by DXGW ID mapping specific targets (missing keys default to 'high'). Defaults to 'high'. AgentCore gateway schema doesn't support oneOf \u2014 the handler accepts either shape."
+                            "description": "Target tier. Pass a string 'high' or 'maximum' to apply to every DXGW, OR an object keyed by DXGW ID mapping specific targets (missing keys default to 'high'). Defaults to 'high'. AgentCore gateway schema doesn't support oneOf \u2014 the handler accepts either shape.",
+                            "properties": {}
                         },
                         "default_region": {
                             "type": "string",
@@ -736,11 +806,13 @@
                         },
                         "topology": {
                             "type": "object",
-                            "description": "Optional cached topology. Omit to re-fetch."
+                            "description": "Optional cached topology. Omit to re-fetch.",
+                            "properties": {}
                         },
                         "targets": {
                             "type": "object",
-                            "description": "Same semantics as assess_dx_resiliency.targets \u2014 pass a string 'high'/'maximum' OR an object keyed by DXGW ID."
+                            "description": "Same semantics as assess_dx_resiliency.targets \u2014 pass a string 'high'/'maximum' OR an object keyed by DXGW ID.",
+                            "properties": {}
                         },
                         "default_region": {
                             "type": "string"
@@ -799,7 +871,8 @@
                         },
                         "topology": {
                             "type": "object",
-                            "description": "Optional cached topology."
+                            "description": "Optional cached topology.",
+                            "properties": {}
                         },
                         "default_region": {
                             "type": "string"
@@ -840,11 +913,15 @@
                     "properties": {
                         "required_tags": {
                             "type": "array",
-                            "description": "Optional caller-supplied list of required tags. Either a flat list of key strings (e.g. ['Environment', 'Owner']) or a list of objects with per-key allowed values (e.g. [{'key': 'Environment', 'allowed_values': ['prod', 'dev']}]). Omit to read from AWS Organizations Tag Policy."
+                            "description": "Optional caller-supplied list of required tags. Either a flat list of key strings (e.g. ['Environment', 'Owner']) or a list of objects with per-key allowed values (e.g. [{'key': 'Environment', 'allowed_values': ['prod', 'dev']}]). Omit to read from AWS Organizations Tag Policy. Items are tag-key strings; for per-key allowed values pass the allowed_values map instead.",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "allowed_values": {
                             "type": "object",
-                            "description": "Optional map of tag_key -> list of permitted values. Overrides any embedded allowed_values in the required_tags parameter."
+                            "description": "Optional map of tag_key -> list of permitted values. Overrides any embedded allowed_values in the required_tags parameter. Shape: an object mapping each tag key to an array of permitted string values, e.g. {\"Environment\": [\"prod\", \"dev\", \"staging\"]}.",
+                            "properties": {}
                         }
                     }
                 }
@@ -864,17 +941,21 @@
             },
             {
                 "name": "check_tag_compliance",
-                "description": "Scan AWS resources and report tag compliance. Two evaluation modes: (1) In-Python classifier (default) uses AWS Resource Explorer as the inventory source and requires a resolved required-tag policy (caller-supplied or Organizations Tag Policy). (2) AWS server-side evaluation (set use_aws_evaluation=true) uses ResourceGroupsTaggingAPI GetResources with IncludeComplianceDetails and requires an attached AWS Tag Policy; caller-supplied required_tags is ignored in this mode. Returns summary counts (compliant/non_compliant/compliance_pct in default mode), breakdowns by violation type and by required tag, top-10 worst-offending resource types, accounts, and regions, a capped list of non-compliant resources with their specific violations, and a complete remediation_buckets array (aggregated counts per (account, region, resource_type, tag_key, violation_type)) that survives the max_resources cap and is the preferred input to get_remediation_guidance. By default excludes system-managed resource types (SageMaker trial components, default parameter groups, etc.) that operators can't practically tag. If Resource Explorer is not indexed and default mode is requested, returns a clear 'resource_explorer_not_indexed' status.",
+                "description": "Scan AWS resources and report tag compliance. Two evaluation modes: (1) In-Python classifier (default) uses AWS Resource Explorer as the inventory source and requires a resolved required-tag policy (caller-supplied or Organizations Tag Policy). (2) AWS server-side evaluation (set use_aws_evaluation=true) uses ResourceGroupsTaggingAPI GetResources with IncludeComplianceDetails and requires an attached AWS Tag Policy; caller-supplied required_tags is ignored in this mode. Returns summary counts (compliant/non_compliant/compliance_pct in default mode), breakdowns by violation type and by required tag, top-10 worst-offending resource types, accounts, and regions, a capped list of non-compliant resources with their specific violations, and a complete remediation_buckets array (aggregated counts per (account, region, resource_type, tag_key, violation_type)) that survives the max_resources cap and is the preferred input to get_remediation_guidance. By default excludes system-managed resource types (SageMaker trial components, default parameter groups, etc.) that operators can't practically tag. If Resource Explorer is not indexed and default mode is requested, returns a clear 'resource_explorer_not_indexed' status. SOURCE OF TRUTH: required tags come ONLY from (1) an attached AWS Organizations Tag Policy (used when required_tags is omitted) or (2) tags the user explicitly names (pass via required_tags). NEVER invent tag keys; 'Environment'/'Owner'/'Project' are illustrative, not defaults. If no policy is attached and the user named no tags, ask which tags to check rather than guessing.",
                 "input_schema": {
                     "type": "object",
                     "properties": {
                         "required_tags": {
                             "type": "array",
-                            "description": "Optional: same format as get_required_tags. Omit to use the Organizations Tag Policy. Ignored when use_aws_evaluation=true."
+                            "description": "Optional: same format as get_required_tags. Omit to use the Organizations Tag Policy. Ignored when use_aws_evaluation=true. Items are tag-key strings; for per-key allowed values pass the allowed_values map instead.",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "allowed_values": {
                             "type": "object",
-                            "description": "Optional tag_key -> allowed values map. Ignored when use_aws_evaluation=true."
+                            "description": "Optional tag_key -> allowed values map. Ignored when use_aws_evaluation=true. Shape: an object mapping each tag key to an array of permitted string values, e.g. {\"Environment\": [\"prod\", \"dev\", \"staging\"]}.",
+                            "properties": {}
                         },
                         "use_aws_evaluation": {
                             "type": "boolean",
@@ -1002,17 +1083,45 @@
             },
             {
                 "name": "get_remediation_guidance",
-                "description": "Generate AWS Resource Explorer deep-links to bulk-fix non-compliant resources. Prefer passing remediation_buckets from the check_tag_compliance response (aggregated, complete regardless of max_resources) \u2014 this guarantees priorities are correct. Falls back to non_compliant_resources (per-resource, may be truncated). Emits one link per (account_id, region, resource_type, tag_key, violation_type) bucket, pre-filtered to exactly those resources. Links are ordered by bucket size (most resources first) so the highest-impact fixes appear first, and are capped at max_links (default 20) with a links_truncated flag when more buckets exist. Operator workflow: open link, select resources, Actions > Manage tags > Add/Edit tag. Commercial AWS partition only.",
+                "description": "Generate AWS Resource Explorer deep-links to bulk-fix non-compliant resources. Prefer passing remediation_buckets from the check_tag_compliance response (aggregated, complete regardless of max_resources) \u2014 this guarantees priorities are correct. Falls back to non_compliant_resources (per-resource, may be truncated). Emits one link per (account_id, region, resource_type, tag_key, violation_type) bucket, pre-filtered to exactly those resources. Links are ordered by bucket size (most resources first) so the highest-impact fixes appear first, and are capped at max_links (default 20) with a links_truncated flag when more buckets exist. Operator workflow: open link, select resources, Actions > Manage tags > Add/Edit tag. Commercial AWS partition only. SELF-CONTAINED: if you pass NEITHER remediation_buckets NOR non_compliant_resources, this tool runs check_tag_compliance itself (honoring any required_tags / resource_types / regions / use_aws_evaluation you pass) and generates the links directly \u2014 so you can call it standalone without threading a prior scan's output.",
                 "input_schema": {
                     "type": "object",
                     "properties": {
                         "remediation_buckets": {
                             "type": "array",
-                            "description": "Preferred input: the remediation_buckets array from check_tag_compliance. Each item is {tag_key, violation_type, account_id, region, resource_type, count}. Aggregated server-side, reflects the full scan even when non_compliant_resources is truncated."
+                            "description": "Preferred input: the remediation_buckets array from check_tag_compliance. Each item is {tag_key, violation_type, account_id, region, resource_type, count}. Aggregated server-side, reflects the full scan even when non_compliant_resources is truncated.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "tag_key": {
+                                        "type": "string"
+                                    },
+                                    "violation_type": {
+                                        "type": "string",
+                                        "description": "missing_tag or invalid_value"
+                                    },
+                                    "account_id": {
+                                        "type": "string"
+                                    },
+                                    "region": {
+                                        "type": "string"
+                                    },
+                                    "resource_type": {
+                                        "type": "string"
+                                    },
+                                    "count": {
+                                        "type": "integer"
+                                    }
+                                }
+                            }
                         },
                         "non_compliant_resources": {
                             "type": "array",
-                            "description": "Fallback input when remediation_buckets is not available. Array of non-compliant resource entries as returned by check_tag_compliance. May be truncated by max_resources, so bucket priorities could be misleading if the scan was large."
+                            "description": "Fallback input when remediation_buckets is not available. Array of non-compliant resource entries as returned by check_tag_compliance. May be truncated by max_resources, so bucket priorities could be misleading if the scan was large.",
+                            "items": {
+                                "type": "object",
+                                "properties": {}
+                            }
                         },
                         "scan_method": {
                             "type": "string",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -71,6 +71,7 @@ module "shared_config" {
   custom_idp_client_secret              = var.custom_idp_client_secret
   app_url                               = var.app_url
   gateway_auth                          = var.gateway_auth
+  jwt_validation_claim                  = var.jwt_validation_claim
   cross_account_role_arn                = try(var.tool_env_vars["cost-explorer"]["CROSS_ACCOUNT_ROLE_ARN"], "")
   cross_account_role_arn_coh            = try(var.tool_env_vars["cost-optimization-hub"]["CROSS_ACCOUNT_ROLE_ARN_COH"], "")
   cross_account_role_arn_tag_governance = try(var.tool_env_vars["tag-governance"]["CROSS_ACCOUNT_ROLE_ARN_TAG_GOVERNANCE"], "")
@@ -111,8 +112,20 @@ module "cognito" {
   # code flow is enabled, so we seed with localhost as a bootstrap. The
   # post-apply hook in deploy.sh then updates `app_url` in
   # config.auto.tfvars.json and re-applies, which swaps localhost out.
-  callback_urls = var.app_url != "" ? ["${var.app_url}/callback/", "http://localhost:3000/"] : ["http://localhost:3000/"]
-  logout_urls   = var.app_url != "" ? ["${var.app_url}/", "http://localhost:3000/"] : ["http://localhost:3000/"]
+  #
+  # When gateway_auth = oauth (Quick integration), also allow-list Quick's
+  # hosted OAuth redirect URLs and generate a client secret — Quick's user-auth
+  # flow requires both. These are additive, so the frontend/localhost callbacks
+  # still work for the AG-UI path.
+  callback_urls = concat(
+    var.app_url != "" ? ["${var.app_url}/callback/", "http://localhost:3000/"] : ["http://localhost:3000/"],
+    var.gateway_auth == "oauth" ? var.quick_oauth_callback_urls : [],
+  )
+  logout_urls     = var.app_url != "" ? ["${var.app_url}/", "http://localhost:3000/"] : ["http://localhost:3000/"]
+  generate_secret = var.gateway_auth == "oauth"
+  # "phone" is requested by Quick's OAuth flow but unused by the AG-UI app —
+  # only allow-list it on the oauth path so the iam/frontend client is unchanged.
+  extra_oauth_scopes = var.gateway_auth == "oauth" ? ["phone"] : []
 }
 
 locals {
@@ -309,6 +322,7 @@ module "agentcore_gateway" {
   # OAuth config (only used when gateway_auth = "oauth")
   cognito_user_pool_id  = local.cognito_user_pool_id
   cognito_app_client_id = local.cognito_app_client_id
+  jwt_validation_claim  = var.jwt_validation_claim
 
   lambda_tool_arns = {
     for k, v in module.lambda_tools : k => v.lambda_function_arn

--- a/terraform/modules/core/agentcore-gateway/main.tf
+++ b/terraform/modules/core/agentcore-gateway/main.tf
@@ -64,8 +64,12 @@ resource "aws_bedrockagentcore_gateway" "this" {
     for_each = var.gateway_auth == "oauth" ? [1] : []
     content {
       custom_jwt_authorizer {
-        discovery_url    = "https://cognito-idp.${data.aws_region.current.region}.amazonaws.com/${var.cognito_user_pool_id}/.well-known/openid-configuration"
-        allowed_audience = [var.cognito_app_client_id]
+        discovery_url = "https://cognito-idp.${data.aws_region.current.region}.amazonaws.com/${var.cognito_user_pool_id}/.well-known/openid-configuration"
+        # Access tokens (Quick) carry the client ID in `client_id`, not `aud`;
+        # ID tokens (AG-UI frontend) carry it in `aud`. Validate the claim the
+        # incoming token type actually populates, or the gateway 403s.
+        allowed_clients  = var.jwt_validation_claim == "client" ? [var.cognito_app_client_id] : null
+        allowed_audience = var.jwt_validation_claim == "audience" ? [var.cognito_app_client_id] : null
       }
     }
   }

--- a/terraform/modules/core/agentcore-gateway/variables.tf
+++ b/terraform/modules/core/agentcore-gateway/variables.tf
@@ -37,3 +37,24 @@ variable "cognito_app_client_id" {
   type        = string
   default     = ""
 }
+
+variable "jwt_validation_claim" {
+  description = <<-EOT
+    Which JWT claim the gateway validates the Cognito client ID against:
+      - "client" (default): validate the `client_id` claim via allowed_clients.
+        Use for clients that send Cognito ACCESS tokens (e.g. Amazon Quick,
+        and OAuth resource-access clients generally). Access tokens have no `aud`
+        claim — they carry the client ID in `client_id` — so audience validation
+        rejects them with 403 insufficient_scope.
+      - "audience": validate the `aud` claim via allowed_audience. Use for clients
+        that send Cognito ID tokens (e.g. the AG-UI frontend), whose `aud` is the
+        client ID.
+  EOT
+  type        = string
+  default     = "client"
+
+  validation {
+    condition     = contains(["client", "audience"], var.jwt_validation_claim)
+    error_message = "jwt_validation_claim must be one of: client, audience"
+  }
+}

--- a/terraform/modules/core/cognito/main.tf
+++ b/terraform/modules/core/cognito/main.tf
@@ -69,11 +69,19 @@ resource "aws_cognito_user_pool_client" "main" {
   name         = "${var.project_tag}-app-client"
   user_pool_id = aws_cognito_user_pool.main.id
 
-  generate_secret = false
+  generate_secret = var.generate_secret
 
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_flows                  = ["code"]
-  allowed_oauth_scopes                 = ["openid", "email", "profile"]
+  # Base scopes the AG-UI frontend needs. `extra_oauth_scopes` is appended only
+  # for the Quick (oauth) path: Amazon Quick reads Cognito's OIDC discovery,
+  # which advertises scopes_supported = [openid, email, phone, profile], and
+  # requests ALL of them ("phone openid profile email"). The app client must
+  # allow every scope Quick requests or Cognito's authorize endpoint returns
+  # invalid_scope — hence "phone" gets added for oauth even though the app
+  # itself doesn't use it. For the iam/frontend path it stays out, so an
+  # existing AG-UI deployment sees no scope change.
+  allowed_oauth_scopes = concat(["openid", "email", "profile"], var.extra_oauth_scopes)
 
   supported_identity_providers = ["COGNITO"]
 

--- a/terraform/modules/core/cognito/variables.tf
+++ b/terraform/modules/core/cognito/variables.tf
@@ -19,3 +19,15 @@ variable "logout_urls" {
   type        = list(string)
   default     = ["http://localhost:8501"]
 }
+
+variable "generate_secret" {
+  description = "Generate a client secret (confidential client). Required for Amazon Quick's user-auth OAuth, which asks for a Client Secret. The AG-UI frontend uses a public client (false)."
+  type        = bool
+  default     = false
+}
+
+variable "extra_oauth_scopes" {
+  description = "Additional allowed OAuth scopes appended to the base [openid, email, profile]. The root module passes [\"phone\"] only when gateway_auth = oauth (Amazon Quick requests all of Cognito's advertised scopes). Empty for the AG-UI/iam path so existing deployments see no change."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/modules/core/shared-config/main.tf
+++ b/terraform/modules/core/shared-config/main.tf
@@ -38,6 +38,7 @@ locals {
     "idp/client_secret"                          = { type = "SecureString", value = var.custom_idp_client_secret }
     "app/url"                                    = { type = "String", value = var.app_url }
     "gateway/auth"                               = { type = "String", value = var.gateway_auth }
+    "gateway/jwt_validation_claim"               = { type = "String", value = var.jwt_validation_claim }
     "cross_account/default_role_arn"             = { type = "String", value = var.cross_account_role_arn }
     "cross_account/coh_role_arn"                 = { type = "String", value = var.cross_account_role_arn_coh }
     "cross_account/tag_governance_role_arn"      = { type = "String", value = var.cross_account_role_arn_tag_governance }

--- a/terraform/modules/core/shared-config/variables.tf
+++ b/terraform/modules/core/shared-config/variables.tf
@@ -57,6 +57,12 @@ variable "gateway_auth" {
   default     = "iam"
 }
 
+variable "jwt_validation_claim" {
+  description = "OAuth gateway JWT claim to validate the Cognito client ID against — audience (ID tokens, AG-UI) or client (access tokens, Quick). Only used when gateway_auth = oauth."
+  type        = string
+  default     = "audience"
+}
+
 variable "cross_account_role_arn" {
   description = "Default cross-account role ARN used by MCP tools with CROSS_ACCOUNT_ROLE_ARN env var."
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -143,6 +143,39 @@ variable "gateway_auth" {
   }
 }
 
+variable "jwt_validation_claim" {
+  description = <<-EOT
+    Which JWT claim the OAuth gateway authorizer validates the Cognito client ID
+    against. Only consulted when gateway_auth = "oauth"; ignored for iam.
+      - "audience" (default): validate the `aud` claim. Use for callers that send
+        Cognito ID tokens (e.g. the AG-UI frontend). This is the pre-existing
+        behavior, kept as the default so upgrading an existing oauth deployment
+        does not silently change validation.
+      - "client": validate the `client_id` claim. Use for callers that send
+        Cognito ACCESS tokens (e.g. Amazon Quick and OAuth resource-access
+        MCP clients generally) — access tokens have no `aud` claim, so audience
+        validation 403s them. `make configure` offers this as the default once
+        you pick gateway_auth = oauth.
+  EOT
+  type        = string
+  default     = "audience"
+
+  validation {
+    condition     = contains(["client", "audience"], var.jwt_validation_claim)
+    error_message = "jwt_validation_claim must be one of: client, audience"
+  }
+}
+
+variable "quick_oauth_callback_urls" {
+  description = "Amazon Quick OAuth redirect URLs to allow-list on the Cognito app client when gateway_auth = oauth. Region-specific; defaults to the three Quick regions. Quick uses one of these as its Redirect URL in the MCP integration."
+  type        = list(string)
+  default = [
+    "https://us-east-1.quicksight.aws.amazon.com/sn/oauthcallback",
+    "https://us-west-2.quicksight.aws.amazon.com/sn/oauthcallback",
+    "https://eu-west-1.quicksight.aws.amazon.com/sn/oauthcallback",
+  ]
+}
+
 variable "tool_env_vars" {
   description = "Per-tool environment variables resolved from .env. Map of tool_name -> { key = value }."
   type        = map(map(string))

--- a/tests/unit/test_tag_governance_tool.py
+++ b/tests/unit/test_tag_governance_tool.py
@@ -484,3 +484,57 @@ class TestGetRemediationGuidance:
         assert len(result["links"]) == 2
         assert result["links_truncated"] is True
         assert result["links_dropped"] == 3
+
+    def test_self_fetches_compliance_when_no_input(self, monkeypatch):
+        """No buckets and no resources → runs check_tag_compliance internally."""
+        called = {}
+
+        def fake_compliance(event):
+            called["event"] = event
+            return {
+                "scan_method": "resource_explorer",
+                "remediation_buckets": [
+                    {
+                        "tag_key": "Environment",
+                        "violation_type": "missing_tag",
+                        "account_id": "111",
+                        "region": "us-east-1",
+                        "resource_type": "ec2:instance",
+                        "count": 7,
+                    },
+                ],
+            }
+
+        monkeypatch.setattr(handler, "handle_check_tag_compliance", fake_compliance)
+
+        result = handler.handle_get_remediation_guidance(
+            {"required_tags": ["Environment"], "resource_types": ["ec2:instance"]}
+        )
+        # The compliance scan received the same event (params threaded through).
+        assert called["event"]["required_tags"] == ["Environment"]
+        assert called["event"]["resource_types"] == ["ec2:instance"]
+        # Regenerated bucket produced a link.
+        assert len(result["links"]) == 1
+        assert result["links"][0]["resource_count"] == 7
+
+    def test_self_fetch_propagates_no_policy_error(self, monkeypatch):
+        """A non-success compliance response is surfaced verbatim, not swallowed."""
+        monkeypatch.setattr(
+            handler,
+            "handle_check_tag_compliance",
+            lambda event: handler._NO_POLICY_FOUND_ERROR,
+        )
+        result = handler.handle_get_remediation_guidance({})
+        assert result == handler._NO_POLICY_FOUND_ERROR
+        assert "links" not in result
+
+    def test_self_fetch_all_compliant_returns_no_links(self, monkeypatch):
+        """Self-fetch yielding zero buckets falls through to the clean summary."""
+        monkeypatch.setattr(
+            handler,
+            "handle_check_tag_compliance",
+            lambda event: {"scan_method": "resource_explorer", "remediation_buckets": []},
+        )
+        result = handler.handle_get_remediation_guidance({})
+        assert result["links"] == []
+        assert "compliant" in result["summary"].lower()


### PR DESCRIPTION
  ### What
  Adapts the Gateway tool layer so an external **Amazon Quick** MCP connector
  (gateway-only + `oauth` deploy path) can discover and invoke the tools, with
  schemas/descriptions enriched for Quick's planner. **No change to the iam /
  AG-UI deployment paths** — every new behavior is gated on `gateway_auth=oauth`.

  ### Why
  A customer is standing up Quick enterprise-wide. Quick's own planner replaces
  this platform's supervisor/orchestrator routing, so the durable asset is the
  Gateway + Lambda tools. We make the tool layer Quick-native rather than
  supervisor-native, deployed as a separate stack via the already-wired
  `DEPLOY_MODE=gateway-only GATEWAY_AUTH=oauth` path.

  ### Changes
  **Schema / handler**
  - `tools.json`: nest `properties`/`items` on the object/array params Quick's
    planner must fill (cost `filter`, pricing `filters`, tag-governance
    `required_tags` / `allowed_values` / `remediation_buckets`); fold per-tool
    domain knowledge into `description`s (CUR amortized-cost reference,
    minimum-calls heuristic, tag source-of-truth rules, DX tier semantics +
    `mock_scenario`). Only nested schema + descriptions survive the
    `sync_gateway_tools` transform, so that's the only lever that reaches Quick.
  - `tag-governance` handler: `get_remediation_guidance` self-fetches via
    `check_tag_compliance` when called with neither `remediation_buckets` nor
    `non_compliant_resources` — lets a planner that can't thread a prior tool's
    JSON output call it standalone. Mirrors `assess_dx_resiliency`'s self-fetch.

  **Auth (all gated on `gateway_auth=oauth`)**
  - New `jwt_validation_claim` var (root + shared-config + gateway module), wired
    through `make configure` as a **conditional oauth-only prompt**. Default
    `audience` preserves existing ID-token behavior (AG-UI); `client` validates
    the `client_id` claim that Quick's **access tokens** carry (access tokens
    have no `aud` claim, so audience validation 403s them).
  - Cognito: `generate_secret` + Quick OAuth callback URLs on the oauth path;
    the `phone` scope is gated behind a new `extra_oauth_scopes` var (oauth only,
    because Quick requests every scope Cognito advertises).

  ### Testing
  - `terraform validate` → Success; `terraform fmt` clean.
  - 3 new tag-governance self-fetch tests; full unit suite green.
  - iam/full path unaffected: new vars default to inert values; no Cognito or
    gateway diff for non-oauth deployments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.