### PR TITLE
fix: report-mode stuck on follow-ups + run-local Cognito cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ make destroy        # Tear down infrastructure
 make destroy-all    # Nuclear: infra + ECR + memory + state backend
 ```
 
+> **Local dev & the Cognito allow-list.** `make run-local` temporarily adds
+> `http://localhost:3000/` to the Cognito app client's callback/logout URLs on
+> start and removes it on a clean exit (see `scripts/run-local.sh`). If the
+> process is terminated uncleanly (SIGKILL, closed terminal, crash), that
+> localhost entry can linger in the allow-list. It's harmless to the deployed
+> site — production auth uses the CloudFront callback, not localhost — but it's
+> good hygiene to keep a `localhost` redirect out of a long-lived app client.
+> Remove a stale entry by re-running `make run-local` and exiting it cleanly
+> (Ctrl-C), or delete it from the Cognito console. Never commit `localhost` as a
+> permanent Terraform-managed callback URL.
+
 ---
 
 ## Deployment options

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -16,6 +16,13 @@ TERRAFORM_DIR="$PROJECT_ROOT/terraform"
 FRONTEND_DIR="$PROJECT_ROOT/src/frontend"
 LOCALHOST_URL="http://localhost:3000/"
 
+# Absolute path to the venv Python. MUST be absolute: this script cd's into
+# $FRONTEND_DIR before launching `next dev`, so the Cognito-cleanup trap runs
+# with cwd=src/frontend. A relative ".venv/bin/python" would fail there with
+# "No such file or directory", silently skipping the localhost allow-list
+# removal and leaving a stale localhost callback in the app client on exit.
+PYTHON="$PROJECT_ROOT/.venv/bin/python"
+
 # Source .env for AWS_PROFILE, AWS_REGION, PROJECT_PREFIX, etc.
 if [ -f "$PROJECT_ROOT/.env" ]; then
   set -a
@@ -84,7 +91,7 @@ _list_contains() {
   # here-string silently replaces the heredoc script) and Python would try
   # to run the JSON as source, failing on `true`/`false` literals.
   local needle="$1" haystack_json="$2"
-  .venv/bin/python - "$needle" "$haystack_json" <<'PY'
+  "$PYTHON" - "$needle" "$haystack_json" <<'PY'
 import json, sys
 needle = sys.argv[1]
 try:
@@ -104,7 +111,7 @@ _update_cognito_urls() {
   # client's config by posting a minimal update. Pass the Cognito
   # describe-client response as argv[7] — two stdin redirects collide and
   # Python would try to run the JSON as source.
-  .venv/bin/python - "$COGNITO_USER_POOL_ID" "$COGNITO_APP_CLIENT_ID" \
+  "$PYTHON" - "$COGNITO_USER_POOL_ID" "$COGNITO_APP_CLIENT_ID" \
     "$AWS_REGION" "${AWS_PROFILE:-default}" \
     "$callbacks_json" "$logouts_json" "$current" <<'PY'
 import json, subprocess, sys
@@ -144,12 +151,12 @@ _cognito_whitelist_add() {
   local json
   json=$(_get_cognito_client_json)
   local current_cb current_lo
-  current_cb=$(.venv/bin/python -c "import json,sys; d=json.load(sys.stdin).get('UserPoolClient',{}); print(json.dumps(d.get('CallbackURLs',[])))" <<<"$json")
-  current_lo=$(.venv/bin/python -c "import json,sys; d=json.load(sys.stdin).get('UserPoolClient',{}); print(json.dumps(d.get('LogoutURLs',[])))" <<<"$json")
+  current_cb=$("$PYTHON" -c "import json,sys; d=json.load(sys.stdin).get('UserPoolClient',{}); print(json.dumps(d.get('CallbackURLs',[])))" <<<"$json")
+  current_lo=$("$PYTHON" -c "import json,sys; d=json.load(sys.stdin).get('UserPoolClient',{}); print(json.dumps(d.get('LogoutURLs',[])))" <<<"$json")
 
   local new_cb new_lo
-  new_cb=$(.venv/bin/python -c "import json,sys; u='$LOCALHOST_URL'; lst=json.loads(sys.stdin.read()); print(json.dumps(lst if u in lst else lst+[u]))" <<<"$current_cb")
-  new_lo=$(.venv/bin/python -c "import json,sys; u='$LOCALHOST_URL'; lst=json.loads(sys.stdin.read()); print(json.dumps(lst if u in lst else lst+[u]))" <<<"$current_lo")
+  new_cb=$("$PYTHON" -c "import json,sys; u='$LOCALHOST_URL'; lst=json.loads(sys.stdin.read()); print(json.dumps(lst if u in lst else lst+[u]))" <<<"$current_cb")
+  new_lo=$("$PYTHON" -c "import json,sys; u='$LOCALHOST_URL'; lst=json.loads(sys.stdin.read()); print(json.dumps(lst if u in lst else lst+[u]))" <<<"$current_lo")
 
   if [ "$new_cb" != "$current_cb" ]; then WE_ADDED_CALLBACK=1; fi
   if [ "$new_lo" != "$current_lo" ]; then WE_ADDED_LOGOUT=1; fi
@@ -175,15 +182,15 @@ _cognito_whitelist_remove() {
   local json
   json=$(_get_cognito_client_json)
   local current_cb current_lo new_cb new_lo
-  current_cb=$(.venv/bin/python -c "import json,sys; d=json.load(sys.stdin).get('UserPoolClient',{}); print(json.dumps(d.get('CallbackURLs',[])))" <<<"$json")
-  current_lo=$(.venv/bin/python -c "import json,sys; d=json.load(sys.stdin).get('UserPoolClient',{}); print(json.dumps(d.get('LogoutURLs',[])))" <<<"$json")
+  current_cb=$("$PYTHON" -c "import json,sys; d=json.load(sys.stdin).get('UserPoolClient',{}); print(json.dumps(d.get('CallbackURLs',[])))" <<<"$json")
+  current_lo=$("$PYTHON" -c "import json,sys; d=json.load(sys.stdin).get('UserPoolClient',{}); print(json.dumps(d.get('LogoutURLs',[])))" <<<"$json")
   if [ "$WE_ADDED_CALLBACK" = 1 ]; then
-    new_cb=$(.venv/bin/python -c "import json,sys; u='$LOCALHOST_URL'; print(json.dumps([x for x in json.loads(sys.stdin.read()) if x!=u]))" <<<"$current_cb")
+    new_cb=$("$PYTHON" -c "import json,sys; u='$LOCALHOST_URL'; print(json.dumps([x for x in json.loads(sys.stdin.read()) if x!=u]))" <<<"$current_cb")
   else
     new_cb="$current_cb"
   fi
   if [ "$WE_ADDED_LOGOUT" = 1 ]; then
-    new_lo=$(.venv/bin/python -c "import json,sys; u='$LOCALHOST_URL'; print(json.dumps([x for x in json.loads(sys.stdin.read()) if x!=u]))" <<<"$current_lo")
+    new_lo=$("$PYTHON" -c "import json,sys; u='$LOCALHOST_URL'; print(json.dumps([x for x in json.loads(sys.stdin.read()) if x!=u]))" <<<"$current_lo")
   else
     new_lo="$current_lo"
   fi

--- a/src/frontend/src/app/MyRuntimeProvider.tsx
+++ b/src/frontend/src/app/MyRuntimeProvider.tsx
@@ -40,6 +40,19 @@ const MyModelAdapter: ChatModelAdapter = {
     const reportTemplateId = (typeof window !== "undefined" && window.__reportTemplateId) || null;
     if (typeof window !== "undefined") window.__reportTemplateId = null;
 
+    // Fire the end-of-turn signal exactly once, no matter how this generator
+    // exits (normal finish, HTTP error, stream read failure, backend error
+    // event, or abort). Listeners use it to reset one-shot composer state —
+    // report mode and edit target. If ANY exit path skips it, that state stays
+    // stuck and the NEXT normal turn wrongly renders as a report. Idempotent so
+    // it's safe to call from a finally AND leave existing explicit calls in.
+    let streamDoneFired = false;
+    const streamDone = () => {
+      if (streamDoneFired) return;
+      streamDoneFired = true;
+      if (typeof window !== "undefined") window.dispatchEvent(new Event("chat-stream-done"));
+    };
+
     // Show thinking indicator immediately. The "Generating report…" artifact
     // card is no longer pre-emitted — we wait for the backend's first signal
     // (<report-pending> for templated, <report-body>/artifact_meta for
@@ -94,7 +107,9 @@ const MyModelAdapter: ChatModelAdapter = {
     });
 
     if (!res.ok) {
-      yield { content: [{ type: "text" as const, text: `Error: ${await res.text()}` }] };
+      const errText = await res.text();
+      streamDone();
+      yield { content: [{ type: "text" as const, text: `Error: ${errText}` }] };
       return;
     }
 
@@ -104,6 +119,8 @@ const MyModelAdapter: ChatModelAdapter = {
         detail: { sessionId, prompt },
       }));
     }
+
+    try {
 
     const reader = res.body!.getReader();
     const decoder = new TextDecoder();
@@ -308,7 +325,7 @@ const MyModelAdapter: ChatModelAdapter = {
               }
             }
             yield { content: buildContent(segments, false, isReportMode) };
-            if (typeof window !== "undefined") window.dispatchEvent(new Event("chat-stream-done"));
+            streamDone();
             return;
           }
 
@@ -383,7 +400,13 @@ const MyModelAdapter: ChatModelAdapter = {
     yield { content: buildContent(segments, true, isReportMode) };
     yield { content: buildContent(segments, false, isReportMode) };
 
-    if (typeof window !== "undefined") window.dispatchEvent(new Event("chat-stream-done"));
+    } finally {
+      // Runs on every exit from the streaming block: normal finish, the
+      // RUN_FINISHED/error `return`s, a `reader.read()` throw, or generator
+      // abort (assistant-ui calls .return() on the iterator when the user
+      // stops or navigates). Guarantees one-shot composer state is reset.
+      streamDone();
+    }
   },
 };
 

--- a/src/frontend/src/components/Thread.tsx
+++ b/src/frontend/src/components/Thread.tsx
@@ -168,7 +168,17 @@ function Composer() {
   }, [reportMode]);
 
   useEffect(() => {
-    const handler = () => setReportMode(false);
+    const handler = () => {
+      setReportMode(false);
+      // Also clear the window global DIRECTLY. setReportMode(false) is a no-op
+      // when reportMode is already false — which is exactly the case for report
+      // flows that set window.__chatMode from page.tsx (template generate,
+      // adhoc report) without flipping this component's state. In that case the
+      // reportMode effect below never re-runs, so the global would stay stuck at
+      // "report" and the NEXT (normal) turn would wrongly render as a report.
+      // Clearing here guarantees the reset regardless of React state.
+      if (typeof window !== "undefined") window.__chatMode = null;
+    };
     window.addEventListener("chat-stream-done", handler);
     return () => window.removeEventListener("chat-stream-done", handler);
   }, []);


### PR DESCRIPTION
Two related bug fixes found + verified against a local dev stack.

  ## 1. Report mode stuck on follow-ups (frontend)
  After generating a report, the next normal chat turn was wrongly rendered as a
  report. Root cause: window.__chatMode was set directly by page.tsx report flows
  without flipping the Composer's React state, so the only reset path
  (chat-stream-done → setReportMode(false)) was a no-op and left the global stuck.
  - Clear window.__chatMode directly on chat-stream-done.
  - Wrap the stream loop in try/finally so the done event fires on every exit
    (error / abort paths previously skipped it).
  Verified with a Playwright regression: reproduced on the pre-fix build, gone after.

  ## 2. run-local.sh Cognito cleanup silently failing (scripts)
  The exit trap ran with cwd=src/frontend, where the relative .venv/bin/python
  call failed — so localhost was never removed from the Cognito allow-list on exit.
  Fixed with an absolute python path; documented the behavior in the README.
  Verified end-to-end: adds localhost on start, removes on clean exit.