### PR TITLE
fix(terraform): manage supervisor AGUI protocol natively, drop deploy-script workaround

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,21 +50,16 @@ Each `server.py` reads `AGENT_NAME` from env, loads its config from
 - Sub-agents are **stateless**: the supervisor resolves ambiguous
   references ("this", "last month") from memory before delegating.
 
-### The AGUI protocol dance
+### Runtime protocol
 
-Terraform provider v6.36 doesn't support `"AGUI"` as a `server_protocol`
-enum. The supervisor needs AGUI at runtime. `scripts/deploy.sh` handles
-the lifecycle:
+The supervisor runtime serves the AG-UI streaming protocol; every other
+agent runtime serves HTTP. Both are set by Terraform via
+`protocol_configuration`. AGUI is a native `server_protocol` enum as of
+AWS provider v6.50.0 (pinned in `terraform/versions.tf`), so there is no
+post-deploy protocol adjustment.
 
-1. Before any terraform op (apply/plan/destroy), `run_terraform()`
-   auto-reverts the frontend agent AGUI→HTTP via boto3. The provider
-   crashes on read/refresh if it sees AGUI.
-2. Terraform applies cleanly seeing HTTP.
-3. `_sync_agent($FRONTEND_AGENT)` post-deploy sets AGUI back
-   unconditionally.
-
-Every agent in `hierarchy.json` MUST declare `"protocol": "http"` —
-including the supervisor.
+The `protocol` field in `hierarchy.json` is unrelated to the runtime
+protocol — no code reads it — so it stays `"http"` for every agent.
 
 ---
 
@@ -286,7 +281,7 @@ NOT `allowed_clients`. Cognito ID tokens carry client ID in `aud`, not
 - `build.sh` — ECR login, agent images (type-aware hashing, per-agent
   hierarchy slicing), frontend build, `.env.local` auto-generation.
 - `terraform.sh` — bootstrap, tfvars generation, plan/apply/destroy,
-  AGUI protocol workaround, fingerprinted init skip.
+  fingerprinted init skip.
 - `sync.sh` — runtime sync, gateway tool schemas, observability, S3
   deploy.
 - `teardown.sh` — ECR cleanup, memory cleanup, state backend cleanup.

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,12 +47,9 @@ Each generic `server.py` reads `AGENT_NAME` from env and loads config from `hier
 
 **Runtime topology.** Each agent is a container on AgentCore Runtime (port 8080). Agent-to-agent calls use `boto3.client('bedrock-agentcore').invoke_agent_runtime()` (SigV4-signed) — NOT Strands `A2AAgent`. Sub-agents are **stateless**: the supervisor resolves ambiguous references ("this", "last month") from memory before delegating. Memory lives on the supervisor only, managed manually via `create_event`/`list_events` in `shared/memory.py` — `AgentCoreMemorySessionManager` is NOT used because `ag_ui_strands.StrandsAgent` discards `session_manager`/`messages`/`callback_handler` and creates its own internal agents per thread (injected via `_agents_by_thread[thread_id]`).
 
-**Protocol field quirk.** Every agent in `hierarchy.json` MUST have `protocol: "http"` — even the supervisor. The Terraform provider v6.36 doesn't support `AGUI` as a `server_protocol` enum. `scripts/deploy.sh` handles the AGUI switch post-deploy:
-1. Before any Terraform operation, `run_terraform()` auto-reverts the frontend agent AGUI→HTTP (provider crashes on read/refresh with AGUI).
-2. Terraform applies cleanly seeing HTTP.
-3. `_sync_agent($FRONTEND_AGENT)` post-deploy sets AGUI back unconditionally.
+**Runtime protocol.** The frontend/supervisor runtime serves the AG-UI streaming protocol; every other agent runtime serves HTTP. Both are set by Terraform via `protocol_configuration { server_protocol = ... }` — AGUI is a native provider enum as of AWS provider v6.50.0 (pinned in `terraform/versions.tf`), so there's no post-deploy protocol dance. The `protocol` field in `hierarchy.json` is unrelated to the runtime protocol (nothing reads it); leave it `"http"`.
 
-If you see silent 424 errors with no useful logs: check for a protocol mismatch.
+If you see silent 424 errors with no useful logs: check for a protocol mismatch on the runtime.
 
 **Tool layer.** Lambda MCP tools live under `src/lambda/mcp/<tool>/` (one per AWS API surface). Schemas are in `src/lambda/mcp/tools.json`. Tools are registered as targets on a single AgentCore Gateway. Gateway targets reset to single-tool placeholder schemas on every `terraform apply`, so `deploy.sh` deletes `.lambda-hashes/gateway-tools.sha` immediately after apply to force `sync_gateway_tools` to re-upload the full multi-tool schemas.
 

--- a/scripts/lib/sync.sh
+++ b/scripts/lib/sync.sh
@@ -157,8 +157,10 @@ _sync_agent() {
   agent_changed=$(get_agent_changed "$agent_name")
 
   # --- For unchanged non-frontend agents, skip the full sync ---
-  # Frontend agent always needs sync (AGUI protocol check after TF reverts to HTTP).
-  # Other agents only need sync when their image changed.
+  # The frontend agent always runs the full sync so its runtime env vars
+  # (registry table, gateway endpoint, memory ID — some known only after
+  # apply) are guaranteed current. Other agents only need sync when their
+  # image changed.
   if [ "$agent_changed" != "true" ] && [ "$agent_name" != "$FRONTEND_AGENT" ]; then
     info "${agent_name}: unchanged, skipping sync"
     return
@@ -180,10 +182,9 @@ kwargs = dict(
 )
 if rt.get('authorizerConfiguration'):
     kwargs['authorizerConfiguration'] = rt['authorizerConfiguration']
-# Frontend agent uses AGUI (TF provider doesn't support it yet); others preserve existing
-if '${agent_name}' == '${FRONTEND_AGENT}':
-    kwargs['protocolConfiguration'] = {'serverProtocol': 'AGUI'}
-elif rt.get('protocolConfiguration'):
+# Preserve the protocol Terraform set (AGUI for the frontend, HTTP for
+# others) — update_agent_runtime is not partial, so omitting it resets it.
+if rt.get('protocolConfiguration'):
     kwargs['protocolConfiguration'] = rt['protocolConfiguration']
 resp = client.update_agent_runtime(**kwargs)
 print(f'${agent_name} updated — version: {resp.get(\"agentRuntimeVersion\", \"unknown\")}')
@@ -255,40 +256,13 @@ else:
     )
     if rt.get('authorizerConfiguration'):
         kwargs['authorizerConfiguration'] = rt['authorizerConfiguration']
-    # Frontend agent uses AGUI (TF provider doesn't support it yet); others preserve existing
-    if '${agent_name}' == '${FRONTEND_AGENT}':
-        kwargs['protocolConfiguration'] = {'serverProtocol': 'AGUI'}
-    elif rt.get('protocolConfiguration'):
+    # Preserve the protocol Terraform set (AGUI for the frontend, HTTP for
+    # others) — update_agent_runtime is not partial, so omitting it resets it.
+    if rt.get('protocolConfiguration'):
         kwargs['protocolConfiguration'] = rt['protocolConfiguration']
     client.update_agent_runtime(**kwargs)
     print('${agent_name} env vars updated')
 " 2>&1 || warn "${agent_name} env var sync failed (non-fatal)"
-
-  # --- Ensure frontend agent protocol is AGUI (TF provider can't set it) ---
-  if [ "$agent_name" = "$FRONTEND_AGENT" ]; then
-    .venv/bin/python -c "
-import boto3
-client = boto3.client('bedrock-agentcore-control', region_name='${AWS_REGION}')
-rt = client.get_agent_runtime(agentRuntimeId='${runtime_id}')
-proto = rt.get('protocolConfiguration', {}).get('serverProtocol', '')
-if proto == 'AGUI':
-    print('${agent_name} protocol already AGUI')
-else:
-    print(f'${agent_name} protocol is {proto}, setting to AGUI...')
-    kwargs = dict(
-        agentRuntimeId='${runtime_id}',
-        agentRuntimeArtifact=rt['agentRuntimeArtifact'],
-        roleArn=rt['roleArn'],
-        networkConfiguration=rt['networkConfiguration'],
-        environmentVariables=rt.get('environmentVariables', {}),
-        protocolConfiguration={'serverProtocol': 'AGUI'},
-    )
-    if rt.get('authorizerConfiguration'):
-        kwargs['authorizerConfiguration'] = rt['authorizerConfiguration']
-    resp = client.update_agent_runtime(**kwargs)
-    print(f'${agent_name} protocol set to AGUI (version: {resp.get(\"agentRuntimeVersion\", \"?\")})')
-" 2>&1 || warn "${agent_name} AGUI protocol set failed (non-fatal)"
-  fi
 
   # --- Wait for READY ---
   info "Waiting for ${agent_name} runtime to be READY..."

--- a/scripts/lib/terraform.sh
+++ b/scripts/lib/terraform.sh
@@ -173,41 +173,6 @@ run_terraform() {
   # populated/total counts. Silent on first-run / missing creds.
   shared_config_print_summary 2>/dev/null || true
 
-  # Workaround: TF provider v6.36 crashes on read if frontend agent has AGUI protocol.
-  # Temporarily revert to HTTP before Terraform runs, then deploy.sh post-deploy
-  # sync sets AGUI back. Needed for both apply and destroy.
-  # Only relevant when agents are deployed.
-  if [ "$DEPLOY_FLAG_AGENTS" = true ]; then
-  local sup_runtime_id
-  sup_runtime_id=$(tf_output agentcore_runtime_id)
-    if [ -n "$sup_runtime_id" ] && [ "$sup_runtime_id" != "" ]; then
-      .venv/bin/python -c "
-import boto3
-client = boto3.client('bedrock-agentcore-control', region_name='${AWS_REGION}')
-try:
-    rt = client.get_agent_runtime(agentRuntimeId='${sup_runtime_id}')
-    proto = rt.get('protocolConfiguration', {}).get('serverProtocol', '')
-    if proto == 'AGUI':
-        kwargs = dict(
-            agentRuntimeId='${sup_runtime_id}',
-            agentRuntimeArtifact=rt['agentRuntimeArtifact'],
-            roleArn=rt['roleArn'],
-            networkConfiguration=rt['networkConfiguration'],
-            environmentVariables=rt.get('environmentVariables', {}),
-            protocolConfiguration={'serverProtocol': 'HTTP'},
-        )
-        if rt.get('authorizerConfiguration'):
-            kwargs['authorizerConfiguration'] = rt['authorizerConfiguration']
-        client.update_agent_runtime(**kwargs)
-        print('Temporarily reverted ${FRONTEND_AGENT} protocol to HTTP for Terraform')
-    else:
-        print(f'${FRONTEND_AGENT} protocol is {proto}, no revert needed')
-except Exception as e:
-    print(f'Protocol revert skipped: {e}')
-" 2>&1 || true
-    fi
-  fi  # end DEPLOY_FLAG_AGENTS check
-
   ensure_terraform_init
 
   # `-var` beats `*.auto.tfvars.json` in Terraform's precedence chain, so

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -13,7 +13,7 @@ All agents are config-driven via `hierarchy.json`. Three generic code folders �
 - `"orchestrator"` — mid-level delegator, routes to ONE child per request.
 - `"frontend"` — user-facing AG-UI entry point (adds memory, suggestions, reports).
 
-`protocol` **must** be `"http"` for every agent, even the frontend. The AGUI switch is handled post-deploy by `scripts/deploy.sh` because Terraform provider v6.36 doesn't support `AGUI` as a `server_protocol` enum.
+`protocol` **must** be `"http"` for every agent, even the frontend. This field is NOT the runtime protocol — no code reads it. The runtime protocol is set by Terraform (`protocol_configuration`): the frontend runtime serves AG-UI, all others serve HTTP.
 
 **Promoting to frontend**: any agent (orchestrator OR worker) can be `type: "frontend"`. `src/agents/frontend/server.py` derives the runtime execution mode from the promoted agent's hierarchy entry — if `children` is non-empty, it runs in mid-level mode (registry-based child delegation); otherwise it runs in leaf mode (gateway MCP tools, same code path as a regular worker). Do NOT hardcode `agent_type="mid_level"` in the frontend factory — a worker promoted to frontend that way loads zero tools and the hallucination guardrail refuses every prompt. See `test_promoted_frontend_has_either_children_or_tools` in `tests/unit/test_topology.py` for the regression guard.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,20 +6,14 @@ Modules live under `modules/core/` (platform) and `modules/custom/` (optional ad
 
 ## Run everything through `make`, not raw `terraform`
 
-- `make plan` / `make deploy-auto` / `make destroy` / `make destroy-all` wrap `scripts/deploy.sh`, which handles: tfvars generation from `hierarchy.json` + `tools.json`, state backend bootstrap, AGUI protocol pre-revert (see below), post-apply syncs (runtime env, gateway tools, registry cleanup), and retry-safe teardown.
-- Raw `terraform apply` skips all of that and leaves you with half-deployed state, stale gateway schemas, and runtime protocol mismatches.
+- `make plan` / `make deploy-auto` / `make destroy` / `make destroy-all` wrap `scripts/deploy.sh`, which handles: tfvars generation from `hierarchy.json` + `tools.json`, state backend bootstrap, post-apply syncs (runtime env, gateway tools, registry cleanup), and retry-safe teardown.
+- Raw `terraform apply` skips all of that and leaves you with half-deployed state, stale gateway schemas, and runtime env-var drift.
 
-## The AGUI protocol dance (read this before touching runtimes)
+## Runtime protocol
 
-Terraform provider v6.36 does **not** support `"AGUI"` as a `server_protocol` enum — only `MCP`, `HTTP`, `A2A`. But our supervisor needs AGUI. The lifecycle is fully automated in `scripts/deploy.sh`:
+The supervisor runtime serves the AG-UI streaming protocol; all other agent runtimes serve HTTP. Both are set by Terraform via `protocol_configuration { server_protocol = ... }` — AGUI became a native `server_protocol` enum in AWS provider v6.50.0 (`versions.tf` pins `>= 6.50.0`), so no post-deploy protocol adjustment is needed.
 
-1. `run_terraform()` pre-step: auto-reverts the frontend agent AGUI→HTTP via boto3 before ANY terraform op (apply/plan/destroy). The provider crashes on read/refresh if it sees AGUI — and `lifecycle { ignore_changes = [protocol_configuration] }` does NOT help because the error happens before plan.
-2. Terraform applies cleanly seeing HTTP.
-3. `_sync_agent("$FRONTEND_AGENT")` post-deploy sets AGUI back via `update_agent_runtime`. Runs unconditionally (not gated on image change).
-
-Terraform `hierarchy.json` has `protocol: "http"` for ALL agents, including the supervisor. Don't change it to `"agui"` or `"a2a"` — causes silent 424 errors.
-
-When the provider adds AGUI support: add `protocol_configuration { server_protocol = "AGUI" }` to `agentcore-runtime/main.tf`, remove the pre-revert and the dedicated protocol check in `deploy.sh`.
+The `protocol` field in `hierarchy.json` is unrelated to the runtime protocol — no code reads it — so it stays `"http"` for every agent, including the supervisor.
 
 ## Modules you'll touch most
 

--- a/terraform/modules/core/agentcore-runtime/main.tf
+++ b/terraform/modules/core/agentcore-runtime/main.tf
@@ -206,11 +206,13 @@ resource "aws_bedrockagentcore_agent_runtime" "this" {
     }
   }
 
-  # NOTE: protocol_configuration { server_protocol = "AGUI" } is desired but
-  # the Terraform AWS provider v6.36 doesn't support the AGUI enum yet (only
-  # MCP, HTTP, A2A). deploy.sh post-deploy sync sets AGUI via the API.
-  # Once the provider adds AGUI support, add the block here and remove the
-  # deploy.sh workaround.
+  # The supervisor is the user-facing entry point and serves the AG-UI
+  # streaming protocol. AGUI became a native server_protocol enum in the
+  # AWS provider v6.50.0 (previously only MCP, HTTP, A2A were accepted),
+  # so Terraform now manages it directly — no post-deploy API workaround.
+  protocol_configuration {
+    server_protocol = "AGUI"
+  }
 
   environment_variables = merge(
     {
@@ -238,7 +240,7 @@ resource "aws_bedrockagentcore_agent_runtime" "this" {
   })
 
   lifecycle {
-    ignore_changes = [authorizer_configuration, protocol_configuration]
+    ignore_changes = [authorizer_configuration]
   }
 }
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,8 +3,11 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 6.35.0"
+      source = "hashicorp/aws"
+      # >= 6.50.0: AGUI became a native server_protocol enum on
+      # aws_bedrockagentcore_agent_runtime. The supervisor's
+      # protocol_configuration relies on it.
+      version = ">= 6.50.0"
     }
   }
 }

--- a/tests/topology/test_slice_and_validate.py
+++ b/tests/topology/test_slice_and_validate.py
@@ -246,8 +246,9 @@ def test_frontend_detection_follows_the_frontend_type(hierarchy, shape):
     frontend, `_load_hierarchy` must report the new agent — NOT the
     hardcoded default `supervisor`.
 
-    A regression here silently deploys the wrong AGUI agent on any
-    non-full topology, which is the exact bug class the topology
+    A regression here mis-identifies the frontend agent on any non-full
+    topology — the wrong agent would get the AGUI runtime protocol and
+    frontend-only env vars — which is the exact bug class the topology
     optimisation entry warns about.
     """
     mutated = _build_topology(hierarchy, shape)
@@ -256,8 +257,8 @@ def test_frontend_detection_follows_the_frontend_type(hierarchy, shape):
         got = _detect_frontend_agent()
     assert got == expected_frontend, (
         f"shape={shape!r}: _load_hierarchy reported FRONTEND_AGENT="
-        f"{got!r}, expected {expected_frontend!r}. The deploy script "
-        "will perform the AGUI swap on the wrong agent."
+        f"{got!r}, expected {expected_frontend!r}. The wrong agent would "
+        "be treated as the frontend (AGUI protocol + frontend env vars)."
     )
 
 

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -142,20 +142,21 @@ class TestHierarchyStructure:
             )
 
     def test_every_entry_uses_http_protocol(self, hierarchy):
-        """Terraform provider v6.36 doesn't support AGUI as a
-        `server_protocol` enum. `hierarchy.json` MUST have
-        `protocol: "http"` for every agent — even the frontend.
-        `deploy.sh` post-swaps the frontend to AGUI after apply.
+        """The `protocol` field in `hierarchy.json` is NOT the runtime
+        protocol — no code reads it. The runtime protocol is set by
+        Terraform (`protocol_configuration`): the frontend runtime serves
+        AG-UI, all others serve HTTP. The field is kept `"http"` for every
+        agent so it never misleads readers into thinking it drives the
+        runtime.
 
-        See docs/development.md "Protocol field quirk" + terraform/README.md.
+        See docs/development.md "Runtime protocol" + terraform/README.md.
         """
         for name, entry in hierarchy.items():
             assert entry["protocol"] == "http", (
                 f"agent {name!r} has protocol={entry['protocol']!r}. "
-                "It MUST be 'http' — the frontend AGUI swap is handled "
-                "post-apply by scripts/deploy.sh. Setting anything "
-                "other than 'http' crashes the Terraform provider at "
-                "plan time or produces silent 424s at runtime."
+                "It MUST be 'http'. This field is vestigial (nothing reads "
+                "it) — the runtime protocol is set by Terraform's "
+                "protocol_configuration, not by this field."
             )
 
     def test_agent_names_are_legal_runtime_identifiers(self, hierarchy):
@@ -186,8 +187,8 @@ class TestHierarchyGraph:
         frontends = [n for n, e in hierarchy.items() if e["type"] == "frontend"]
         assert len(frontends) == 1, (
             f"expected exactly one agent with type='frontend', got "
-            f"{len(frontends)}: {frontends}. The AGUI protocol swap in "
-            "deploy.sh assumes a single frontend agent."
+            f"{len(frontends)}: {frontends}. Terraform sets the AGUI runtime "
+            "protocol on the single frontend agent; more than one is ambiguous."
         )
 
     def test_every_child_reference_resolves(self, hierarchy):


### PR DESCRIPTION
AWS provider v6.50.0 added AGUI as a native server_protocol enum on aws_bedrockagentcore_agent_runtime (repo has v6.52.0 locked), so the coordinated deploy-script workaround for the supervisor's AG-UI protocol is no longer needed.

Changes:
- agentcore-runtime: set protocol_configuration { server_protocol = "AGUI" } and drop protocol_configuration from lifecycle.ignore_changes so Terraform manages it directly.
- terraform.sh: remove the pre-revert that flipped the frontend runtime AGUI→HTTP before every terraform op (the provider no longer crashes reading AGUI).
- sync.sh: remove the post-deploy AGUI-set in _sync_agent; remaining update_agent_runtime calls preserve the existing protocol (the call is not partial).
- versions.tf: pin aws >= 6.50.0 (the real enforcement — init fails loudly on an older provider).
- Docs + test docstrings: replace the "AGUI protocol dance" notes with a short runtime-protocol note. The `protocol` field in hierarchy.json is vestigial (nothing reads it) and stays "http".
    
Verified: 444 unit + 13 topology tests pass; terraform fmt clean; make plan shows 0 destroys and no protocol crash. Deployed in-place AND via full destroy+recreate on dev — supervisor comes up READY at AGUI natively with no protocol dance; smoke test streams with zero 424s in both cases.