### PR TITLE
feat(tag-governance): snapshot collector for fast answers + fix report actor_id derivation

### DIFF
--- a/docs/agents/tag-governance.md
+++ b/docs/agents/tag-governance.md
@@ -13,9 +13,23 @@ reference material.
 
 ## 1. What the feature does
 
-Answers tag-compliance questions on-demand — no collector, no cached
-state. Every query hits the live AWS APIs from the Lambda's account
-and returns a fresh classification.
+Answers tag-compliance questions from a **scheduled snapshot** when one is
+available, falling back to live AWS API queries otherwise.
+
+By default (`enable_tag_snapshots = true`), a collector Lambda sweeps the
+expensive scans on a schedule (`rate(6 hours)`) and stores the responses in
+DynamoDB. Canonical (unfiltered) queries then answer in milliseconds and carry
+`data_as_of` + `data_source: "scheduled_snapshot"`. Three things always go
+live: queries with caller filters (`resource_types`, `regions`,
+`required_tags` override, `use_aws_evaluation`…), `force_refresh=true`, and
+any cache miss (collector disabled, snapshot expired, table unreachable —
+the fallback is silent and the tool behaves exactly as it did pre-collector).
+
+The collector does not reimplement scan logic: it invokes the SAME tool
+Lambda with gateway-shaped requests and stores what comes back, so the live
+and snapshot paths cannot drift. Snapshot staleness is bounded by the item
+TTL (default 48h): if the collector stops running, snapshots expire and the
+tool reverts to live queries rather than serving stale data forever.
 
 Representative prompts:
 
@@ -337,3 +351,6 @@ delete the row to fall back to the JSON.
 | Tag is compliant per policy but doesn't show on the bill | Cost-allocation activation is a separate payer action | Use `list_cost_allocation_tag_status`; activate in Billing → Cost allocation tags |
 | `api_limit_reached: true` in `find_untagged_resources` or `check_tag_compliance` | Resource Explorer Search capped at 1000 results | Pass single `resource_type` or `region` to filter server-side |
 | Report still shows old section count after editing the JSON | DynamoDB shadow row under your actor_id (created by UI save) | Delete the row from `<prefix>-<env>-report-templates` and redeploy |
+| Answers carry `data_source: "scheduled_snapshot"` but numbers look stale | Snapshot age within the schedule window (default 6h) | Ask again with `force_refresh=true`, or check the collector's `LAST_RUN` meta row / CloudWatch logs |
+| Snapshot never serves (every call is slow/live) despite `enable_tag_snapshots = true` | Collector failing (see its log group) or snapshot TTL expired; also every filtered query is live BY DESIGN | `aws logs tail /aws/lambda/<prefix>-tag-governance-collector`; confirm the CACHE rows exist in `<prefix>-tag-compliance-snapshots` |
+| Snapshot responses carry `snapshot_note` about trimmed detail lists | Full detail list exceeded the DynamoDB 400 KB item cap | Counts/breakdowns are still complete; use `force_refresh=true` when the full detail list matters |

--- a/docs/cost-estimate.md
+++ b/docs/cost-estimate.md
@@ -420,6 +420,20 @@ Each question that lands in `health-events-agent`: ~$0.034 leaf Bedrock. No per-
 - **Tier 2 response-size scaling is the only thing that moves this number.** A tag drill-down against a 500-account org returns ~15 KB of JSON; the next turn's Bedrock input cost picks that up (~$0.01 extra per drill-down). Immaterial.
 - Like `pricing-agent`, this is one of the cheapest modules to enable — zero paid AWS APIs, pure Bedrock leaf cost per turn.
 
+**Snapshot collector (`enable_tag_snapshots`, default ON when this tool is deployed)**
+
+A scheduled Lambda (default `rate(6 hours)`) re-runs the expensive sweeps — Resource Explorer inventory + classification — through the tool Lambda and stores the responses in a snapshot table, so canonical tag queries answer from DynamoDB in milliseconds instead of a 3–60s live scan. Filtered queries and `force_refresh=true` still go live.
+
+| Item | Cost | Notes |
+|---|---|---|
+| Collector Lambda (schedule) | $0 | 4 runs/day × ~60s × 256 MB ≈ 1 800 GB-s/mo — inside the 400 000 GB-s free tier. |
+| Tool Lambda re-invocations | $0 | ~5 invocations per sweep (600/mo) — free tier. |
+| EventBridge schedule rule | $0 | Scheduler rules are free. |
+| DynamoDB `tag-compliance-snapshots` | ~$0.01–$0.05 | ~5 items rewritten 4×/day (≤400 KB each): ~120 write-units/day. 48h TTL caps storage under 2 MB. |
+| All AWS scan APIs (Resource Explorer, Tagging, Organizations) | Free | Same free APIs the live path uses — the schedule just moves them off the user's turn. |
+
+**Module cost delta: effectively $0** (worst case ~$0.05/mo DDB). What it buys: tag-governance turns skip the 3–60s scan, so the leaf's Bedrock turn also gets slightly *cheaper* (no retry/continuation prompts on slow tool calls), and report sections stop triple-running the same sweep. At `rate(1 hour)` the numbers stay in free tier; the knob that would eventually cost money is snapshotting a very large estate (approaching the 400 KB item cap) every few minutes — don't do that.
+
 ### 6.7 Side-by-side module summary
 
 Comparing typical module usage at **small-team scale** (5 users, ~1 500 total turns/mo spread across the modules each user actually uses):
@@ -431,7 +445,7 @@ Comparing typical module usage at **small-team scale** (5 users, ~1 500 total tu
 | `pricing-agent` | 100 | — | ~$3.40 | $0 | **~$3** |
 | `health-events-agent` (100-acct org) | 60 | ~$0.55 | ~$2 | $0 | **~$3** |
 | `network-resiliency-agent` | 40 | — | ~$1.40 | $0 | **~$1** |
-| `tag-governance-agent` | 100 | — | ~$3.40 | $0 | **~$3** |
+| `tag-governance-agent` (+ snapshot collector) | 100 | ~$0.05 | ~$3.40 | $0 | **~$3** |
 | **Small-team total (all modules enabled)** | | | | | **~$75–$80** |
 
 (Note this is lower than the §5 "Small team" $208 because §5 uses a heavier 2 250 turns/mo assumption and counts reports. Both are valid framings — §5 is "full platform, typical chatty team"; this table is "what does each feature contribute".)

--- a/scripts/lib/sync.sh
+++ b/scripts/lib/sync.sh
@@ -186,6 +186,10 @@ if rt.get('authorizerConfiguration'):
 # others) — update_agent_runtime is not partial, so omitting it resets it.
 if rt.get('protocolConfiguration'):
     kwargs['protocolConfiguration'] = rt['protocolConfiguration']
+# Preserve the request-header allowlist Terraform set (Authorization forwarding
+# on the supervisor) — same non-partial-update reason as protocol above.
+if rt.get('requestHeaderConfiguration'):
+    kwargs['requestHeaderConfiguration'] = rt['requestHeaderConfiguration']
 resp = client.update_agent_runtime(**kwargs)
 print(f'${agent_name} updated — version: {resp.get(\"agentRuntimeVersion\", \"unknown\")}')
 " 2>&1 || warn "${agent_name} force update failed (non-fatal)"
@@ -260,6 +264,10 @@ else:
     # others) — update_agent_runtime is not partial, so omitting it resets it.
     if rt.get('protocolConfiguration'):
         kwargs['protocolConfiguration'] = rt['protocolConfiguration']
+    # Preserve the request-header allowlist Terraform set (Authorization
+    # forwarding on the supervisor) — same non-partial-update reason.
+    if rt.get('requestHeaderConfiguration'):
+        kwargs['requestHeaderConfiguration'] = rt['requestHeaderConfiguration']
     client.update_agent_runtime(**kwargs)
     print('${agent_name} env vars updated')
 " 2>&1 || warn "${agent_name} env var sync failed (non-fatal)"

--- a/src/agents/shared/agui_server.py
+++ b/src/agents/shared/agui_server.py
@@ -28,6 +28,7 @@ Usage::
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
@@ -71,6 +72,49 @@ logger = logging.getLogger(__name__)
 AGENTCORE_MEMORY_ID = os.environ.get("AGENTCORE_MEMORY_ID", "")
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
 REPORT_TABLE_NAME = os.environ.get("REPORT_TABLE_NAME", "")
+
+
+def _sanitize_actor_id(email: str) -> str:
+    """Sanitize an email into the actor_id form used as a partition-key component.
+
+    MUST stay in lockstep with the frontend's ``sanitizeActorId`` (auth.ts) and
+    core-api's ``_get_actor_id`` (handler.py) — all three produce the key the
+    browser later reads reports/sessions back under.
+    """
+    return email.replace("@", "_at_").replace(".", "_")
+
+
+def _actor_id_from_jwt(request: "Request") -> str:
+    """Derive actor_id from the request's already-validated JWT, if present.
+
+    The runtime's custom_jwt_authorizer verified this token's signature at the
+    platform edge before the request reached the container, so decoding the
+    payload here (WITHOUT re-verifying) is safe — an unverified token never
+    gets this far. Returns "" when there is no bearer token or no email claim
+    (e.g. SigV4 / legacy callers), letting the caller fall back.
+
+    Why this exists: actor_id used to be read only from forwardedProps — a
+    client-controlled field. When the browser sent it empty (getActorId()
+    returns "anonymous"/"" if userEmail hasn't hydrated yet — a real race) or
+    sent a value that diverged from core-api's JWT-derived key, the report row
+    was written under one partition key while the frontend polled another. The
+    report completed in DynamoDB but the UI spun on "Generating…" forever.
+    Deriving from the JWT makes the write key and the poll key come from the
+    same claim, and stops any authenticated user from reading/writing another
+    actor's reports by editing forwardedProps.
+    """
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return ""
+    token = auth[7:].strip()
+    try:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        email = claims.get("email", "")
+        return _sanitize_actor_id(email) if email else ""
+    except Exception:
+        return ""
 
 # Type alias for the agent builder callable.
 # Signature: (payload: dict) -> (Agent, system_prompt: str, cleanup_fn: Optional[Callable])
@@ -132,7 +176,10 @@ def create_agui_app(
         # AG-UI chat
         forwarded = payload.get("forwardedProps", {})
         session_id = forwarded.get("session_id", payload.get("threadId", ""))
-        actor_id = forwarded.get("actor_id", "")
+        # JWT-derived actor wins; forwardedProps is only a fallback for callers
+        # without a bearer token (SigV4 smoke tests, legacy clients). See
+        # _actor_id_from_jwt for the report-orphaning bug this closes.
+        actor_id = _actor_id_from_jwt(request) or forwarded.get("actor_id", "")
 
         # Extract user prompt from AG-UI messages
         user_prompt = _extract_user_prompt(payload)

--- a/src/lambda/collectors/tag-governance/handler.py
+++ b/src/lambda/collectors/tag-governance/handler.py
@@ -1,0 +1,203 @@
+"""
+Tag Governance Collector — scheduled snapshot of org tag-compliance posture.
+
+Triggered by an EventBridge SCHEDULE (default every 6 hours), not by events:
+unlike AWS Health, nothing emits "resource became non-compliant" — compliance
+is a derived scan, so the collector sweeps on a timer.
+
+Architecture:
+    EventBridge schedule → This Lambda → invoke tag-governance TOOL Lambda
+                                       → DynamoDB (tag-compliance snapshot table)
+
+Design decision — invoke the tool, don't reimplement it:
+    The tag-governance MCP tool already owns the policy resolution, Resource
+    Explorer sweep, and per-resource classification (~700 lines, carefully
+    tuned: match-all query semantics, system-managed filtering, dedup,
+    violation buckets). Duplicating that here would drift. Instead this
+    collector calls the SAME Lambda with the same event shapes users trigger,
+    and stores the responses. The tool then serves user requests from the
+    snapshot (millisecond DynamoDB read) instead of a 3–60s live sweep.
+
+What gets snapshotted (the "canonical" shapes — no caller filters):
+    check_tag_compliance            {}                       (full sweep, in-Python mode)
+    get_org_tag_compliance_summary  {"group_by": "TARGET_ID"} (only if a Tag Policy is attached)
+    find_untagged_resources         {}
+    list_tag_keys_in_use            {}
+    get_required_tags               {}
+
+Requests WITH caller filters (specific resource_types, regions, a
+required_tags override…) always go live in the tool — a snapshot computed
+for the canonical query cannot answer a filtered one honestly.
+
+Item layout (single table, TTL'd):
+    pk = "CACHE"    sk = <operation>   payload=<full JSON response>, snapshot_at, ttl
+    pk = "META"     sk = "LAST_RUN"    run summary for observability
+"""
+
+import base64
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+TABLE_NAME = os.environ.get("TAG_SNAPSHOT_TABLE_NAME", "")
+TOOL_FUNCTION_NAME = os.environ.get("TAG_TOOL_FUNCTION_NAME", "")
+SNAPSHOT_TTL_HOURS = int(os.environ.get("SNAPSHOT_TTL_HOURS", "48"))
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Operations swept every run, with their canonical (unfiltered) event shapes.
+# get_org_tag_compliance_summary is attempted but tolerated to fail — it
+# requires an attached AWS Tag Policy + management-account access, and the
+# error response is itself worth caching (the tool would return the same
+# error live, just slower).
+#
+# force_refresh on EVERY payload is load-bearing, not belt-and-braces: the
+# tool serves canonical queries from this collector's own snapshot table, so
+# without it the second scheduled run would read the cache and re-store the
+# same bytes forever — a snapshot that never refreshes. force_refresh pins
+# the collector to the live path; it is stripped from what gets stored only
+# in the sense that responses never echo request fields.
+CANONICAL_OPS: list[tuple[str, dict]] = [
+    ("get_required_tags", {"force_refresh": True}),
+    ("check_tag_compliance", {"max_resources": 1000, "force_refresh": True}),
+    ("find_untagged_resources", {"max_resources": 1000, "force_refresh": True}),
+    ("list_tag_keys_in_use", {"force_refresh": True}),
+    ("get_org_tag_compliance_summary", {"group_by": "TARGET_ID", "force_refresh": True}),
+]
+
+# DynamoDB hard item limit is 400KB. check_tag_compliance against a large
+# estate can carry a big non_compliant_resources detail list; trim the detail
+# list (never the counts — those are pre-computed over the full set) until the
+# item fits. The tool re-truncates to the caller's max_resources anyway.
+_MAX_ITEM_BYTES = 350_000
+_TRIMMABLE_LIST_KEYS = ("non_compliant_resources", "untagged_resources", "resources")
+
+
+def _lambda_client():
+    return boto3.client("lambda", region_name=AWS_REGION)
+
+
+def _ddb():
+    return boto3.client("dynamodb", region_name=AWS_REGION)
+
+
+def _invoke_tool(operation: str, payload: dict) -> dict:
+    """Invoke the tag-governance tool Lambda exactly as the gateway would.
+
+    The tool handler routes on
+    ``context.client_context.custom["bedrockAgentCoreToolName"]`` — Lambda's
+    ``ClientContext`` parameter delivers that verbatim, so no tool-side
+    changes are needed for direct invocation.
+    """
+    ctx = base64.b64encode(
+        json.dumps(
+            {"custom": {"bedrockAgentCoreToolName": f"tag-governance___{operation}"}}
+        ).encode()
+    ).decode()
+    resp = _lambda_client().invoke(
+        FunctionName=TOOL_FUNCTION_NAME,
+        InvocationType="RequestResponse",
+        ClientContext=ctx,
+        Payload=json.dumps(payload).encode(),
+    )
+    body = resp["Payload"].read().decode()
+    if resp.get("FunctionError"):
+        raise RuntimeError(f"{operation} invoke failed: {body[:300]}")
+    return json.loads(body)
+
+
+def _shrink_to_fit(response: dict) -> tuple[dict, bool]:
+    """Trim detail lists until the serialized response fits the DDB item cap.
+
+    Counts/breakdowns are computed by the tool over the FULL result set before
+    truncation, so trimming details here loses granularity, never correctness.
+    """
+    trimmed = False
+    body = json.dumps(response, default=str)
+    while len(body.encode()) > _MAX_ITEM_BYTES:
+        for key in _TRIMMABLE_LIST_KEYS:
+            lst = response.get(key)
+            if isinstance(lst, list) and lst:
+                del lst[len(lst) // 2 :]  # halve from the tail
+                trimmed = True
+                break
+        else:
+            # Nothing left to trim — store an explicit failure marker instead
+            # of a silently-absent snapshot.
+            return (
+                {"error": "snapshot too large for DynamoDB item", "operation": "?"},
+                True,
+            )
+        body = json.dumps(response, default=str)
+    if trimmed:
+        response["snapshot_note"] = (
+            "Detail list trimmed to fit storage; counts and breakdowns reflect "
+            "the full scan. Use force_refresh=true for the complete detail list."
+        )
+    return response, trimmed
+
+
+def _put_cache_item(operation: str, response: dict, snapshot_at: str) -> None:
+    ttl = int(time.time()) + SNAPSHOT_TTL_HOURS * 3600
+    _ddb().put_item(
+        TableName=TABLE_NAME,
+        Item={
+            "pk": {"S": "CACHE"},
+            "sk": {"S": operation},
+            "payload": {"S": json.dumps(response, default=str)},
+            "snapshot_at": {"S": snapshot_at},
+            "ttl": {"N": str(ttl)},
+        },
+    )
+
+
+def handler(event, context):
+    """Sweep every canonical operation and persist the responses."""
+    if not TABLE_NAME or not TOOL_FUNCTION_NAME:
+        raise RuntimeError(
+            "TAG_SNAPSHOT_TABLE_NAME and TAG_TOOL_FUNCTION_NAME must be set"
+        )
+
+    snapshot_at = datetime.now(timezone.utc).isoformat()
+    results: dict[str, str] = {}
+
+    for operation, payload in CANONICAL_OPS:
+        started = time.monotonic()
+        try:
+            response = _invoke_tool(operation, payload)
+            response, trimmed = _shrink_to_fit(response)
+            _put_cache_item(operation, response, snapshot_at)
+            elapsed = time.monotonic() - started
+            status = "ok+trimmed" if trimmed else "ok"
+            # A tool-level error payload (e.g. no Tag Policy attached) is still
+            # a valid snapshot — the tool would return it live too. Record it
+            # distinctly so the run summary shows what's error-cached.
+            if isinstance(response, dict) and response.get("error"):
+                status = "error-cached"
+            results[operation] = f"{status} ({elapsed:.1f}s)"
+            logger.info("snapshot %s: %s", operation, results[operation])
+        except Exception as exc:
+            results[operation] = f"FAILED: {exc}"
+            logger.error("snapshot %s failed: %s", operation, exc)
+
+    # Run summary for observability / debugging staleness questions.
+    _ddb().put_item(
+        TableName=TABLE_NAME,
+        Item={
+            "pk": {"S": "META"},
+            "sk": {"S": "LAST_RUN"},
+            "snapshot_at": {"S": snapshot_at},
+            "results": {"S": json.dumps(results)},
+            "ttl": {"N": str(int(time.time()) + SNAPSHOT_TTL_HOURS * 3600)},
+        },
+    )
+
+    failed = [op for op, r in results.items() if r.startswith("FAILED")]
+    logger.info("=== tag snapshot done: %d ops, %d failed ===", len(results), len(failed))
+    return {"snapshot_at": snapshot_at, "results": results}

--- a/src/lambda/collectors/tag-governance/requirements.txt
+++ b/src/lambda/collectors/tag-governance/requirements.txt
@@ -1,0 +1,1 @@
+# Empty — Lambda Python 3.12 runtime provides boto3/botocore at runtime.

--- a/src/lambda/mcp/tag-governance/handler.py
+++ b/src/lambda/mcp/tag-governance/handler.py
@@ -633,6 +633,79 @@ def _assemble_compliance_response(
 
 
 # ---------------------------------------------------------------------------
+# Snapshot cache (optional, written by the tag-governance collector)
+# ---------------------------------------------------------------------------
+#
+# When TAG_SNAPSHOT_TABLE_NAME is set, a scheduled collector periodically runs
+# the expensive sweeps (Resource Explorer inventory + classification, 3–60s on
+# real estates) and stores the responses. Reads here become millisecond DDB
+# GetItems. Live querying remains for:
+#   * requests with caller filters (resource_types, regions, required_tags
+#     override, non-default max_resources…) — a canonical snapshot cannot
+#     honestly answer a filtered question;
+#   * force_refresh=true (explicit freshness escape hatch);
+#   * cache miss / collector not deployed / table unset — silent fallthrough.
+#
+# Only these ops are snapshot-eligible; the rest are cheap single API calls
+# (list_cost_allocation_tag_status) or static (get_remediation_guidance).
+
+_SNAPSHOT_TABLE = os.environ.get("TAG_SNAPSHOT_TABLE_NAME", "")
+
+# op → the exact caller keys that force a LIVE query when present. Keys the
+# canonical sweep already used (max_resources — details are stored beyond any
+# caller's cap and re-truncated below) do not force liveness.
+_SNAPSHOT_ELIGIBLE: dict[str, tuple[str, ...]] = {
+    "get_required_tags": ("required_tags",),
+    "check_tag_compliance": (
+        "required_tags", "resource_types", "regions",
+        "use_aws_evaluation", "include_system_managed",
+    ),
+    "find_untagged_resources": ("resource_types", "regions"),
+    "list_tag_keys_in_use": ("regions",),
+    "get_org_tag_compliance_summary": ("group_by", "target_ids", "regions"),
+}
+
+
+def _snapshot_lookup(tool_name: str, event: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the cached snapshot for *tool_name*, or None to go live."""
+    if not _SNAPSHOT_TABLE or tool_name not in _SNAPSHOT_ELIGIBLE:
+        return None
+    if event.get("force_refresh"):
+        return None
+    # Any live-forcing filter present (and truthy) → live path.
+    if any(event.get(k) for k in _SNAPSHOT_ELIGIBLE[tool_name]):
+        return None
+    try:
+        resp = boto3.client("dynamodb").get_item(
+            TableName=_SNAPSHOT_TABLE,
+            Key={"pk": {"S": "CACHE"}, "sk": {"S": tool_name}},
+        )
+        item = resp.get("Item")
+        if not item:
+            return None
+        payload = json.loads(item["payload"]["S"])
+        payload["data_as_of"] = item.get("snapshot_at", {}).get("S", "")
+        payload["data_source"] = "scheduled_snapshot"
+        payload["freshness_note"] = (
+            "Served from the scheduled compliance snapshot (fast path). "
+            "Pass force_refresh=true for a live scan."
+        )
+        # Honor the caller's max_resources against the stored detail list —
+        # the snapshot stores up to the sweep cap, callers usually want less.
+        if tool_name in ("check_tag_compliance", "find_untagged_resources"):
+            cap = int(event.get("max_resources", 25))
+            for key in ("non_compliant_resources", "untagged_resources", "resources"):
+                lst = payload.get(key)
+                if isinstance(lst, list) and len(lst) > cap:
+                    payload[key] = lst[:cap]
+                    payload["truncated"] = True
+        return payload
+    except Exception as exc:  # noqa: BLE001 — cache failure must never break the tool
+        logger.warning("snapshot lookup failed (%s); falling back to live", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Tool dispatch
 # ---------------------------------------------------------------------------
 
@@ -648,6 +721,10 @@ def handler(event, context):
             "error": f"Unknown tool: {tool_name}",
             "available_tools": list(_TOOL_HANDLERS.keys()),
         }
+    cached = _snapshot_lookup(tool_name, event or {})
+    if cached is not None:
+        logger.info("Serving %s from snapshot (%s)", tool_name, cached.get("data_as_of"))
+        return cached
     try:
         response = fn(event or {})
         logger.info("Response: %s", json.dumps(response, default=str))

--- a/src/lambda/mcp/tools.json
+++ b/src/lambda/mcp/tools.json
@@ -890,6 +890,7 @@
         "runtime": "python3.12",
         "timeout": 60,
         "memory": 512,
+        "needs_tag_snapshots": true,
         "env_vars": {
             "CROSS_ACCOUNT_ROLE_ARN_TAG_GOVERNANCE": "$CROSS_ACCOUNT_ROLE_ARN_TAG_GOVERNANCE"
         },

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -183,6 +183,25 @@ module "health_events_collection" {
 }
 
 # -----------------------------------------------------------------------------
+# Tag Governance Collection (scheduled compliance snapshots; opt-out via
+# enable_tag_snapshots=false). Deployed only when the tag-governance tool is.
+# -----------------------------------------------------------------------------
+module "tag_governance_collection" {
+  source             = "./modules/custom/tag-governance-collection"
+  count              = var.enable_tag_snapshots && var.deploy_tools && (contains(var.selected_tools, "tag-governance") || length(var.selected_tools) == 0) ? 1 : 0
+  project_tag        = var.project_tag
+  environment_tag    = var.environment_tag
+  collector_zip_path = "${path.module}/../src/lambda/collectors/tag-governance/tag-governance-collector.zip"
+  # Deterministic names from lambda-tool-base ("<project>-<tool>-tool") rather
+  # than module outputs — the tool module reads THIS module's table_name, so
+  # output references both ways would cycle.
+  tool_function_name = "${var.project_tag}-tag-governance-tool"
+  tool_role_name     = "${var.project_tag}-tag-governance-tool-role"
+  snapshot_schedule  = var.tag_snapshot_schedule
+  log_retention_days = var.log_retention_days
+}
+
+# -----------------------------------------------------------------------------
 # Frontend API (only when agents + frontend are deployed)
 # -----------------------------------------------------------------------------
 module "frontend_api" {
@@ -302,6 +321,15 @@ module "lambda_tools" {
     # Infra-derived env vars (override user-provided if both set)
     lookup(each.value, "needs_health_events", false) && length(module.health_events_collection) > 0 ? {
       HEALTH_EVENTS_TABLE_NAME = module.health_events_collection[0].table_name
+    } : {},
+    # Snapshot cache for tag-governance: when the collection module is
+    # deployed, the tool serves canonical (unfiltered) queries from the
+    # snapshot table and falls back to live scans otherwise. The read IAM
+    # grant is attached by the collection module (see tool_role_name there)
+    # because this module's single iam_actions/iam_resources statement
+    # can't scope DDB to one table while the scan APIs need "*".
+    lookup(each.value, "needs_tag_snapshots", false) && length(module.tag_governance_collection) > 0 ? {
+      TAG_SNAPSHOT_TABLE_NAME = module.tag_governance_collection[0].table_name
     } : {},
   )
 

--- a/terraform/modules/core/agentcore-runtime/main.tf
+++ b/terraform/modules/core/agentcore-runtime/main.tf
@@ -214,6 +214,17 @@ resource "aws_bedrockagentcore_agent_runtime" "this" {
     server_protocol = "AGUI"
   }
 
+  # Forward the caller's Authorization header into the container. The runtime
+  # strips all client headers unless allowlisted; the AG-UI server derives
+  # actor_id from the platform-validated JWT in this header (agui_server.py::
+  # _actor_id_from_jwt) so report/session partition keys come from the same
+  # claim core-api uses — without this, actor_id silently falls back to the
+  # client-controlled forwardedProps and reports can be written under a key
+  # the frontend never polls ("Generating…" forever) or spoofed cross-actor.
+  request_header_configuration {
+    request_header_allowlist = ["Authorization"]
+  }
+
   environment_variables = merge(
     {
       AGENT_NAME                 = var.agent_name

--- a/terraform/modules/core/lambda-tool-base/outputs.tf
+++ b/terraform/modules/core/lambda-tool-base/outputs.tf
@@ -7,3 +7,8 @@ output "lambda_function_name" {
   description = "Name of the Lambda function"
   value       = aws_lambda_function.this.function_name
 }
+
+output "lambda_role_name" {
+  description = "Name of the Lambda execution role (for feature modules that attach narrowly-scoped extra grants, e.g. snapshot-table reads)"
+  value       = aws_iam_role.lambda.name
+}

--- a/terraform/modules/custom/tag-governance-collection/main.tf
+++ b/terraform/modules/custom/tag-governance-collection/main.tf
@@ -1,0 +1,195 @@
+# Tag Governance Collection Module
+#
+# Scheduled snapshot pipeline for tag-compliance posture:
+#   EventBridge schedule → collector Lambda → invoke tag-governance TOOL Lambda
+#                                           → DynamoDB (snapshot table)
+#
+# Unlike health-events (event-driven: AWS pushes events onto the bus), tag
+# compliance is a DERIVED scan — nothing emits "resource became non-compliant"
+# — so this pipeline sweeps on a timer instead of consuming a queue. The
+# collector re-uses the tool Lambda for all scan logic (policy resolution,
+# Resource Explorer sweep, classification) so the two paths can never drift;
+# it only orchestrates and stores.
+
+locals {
+  common_tags = {
+    project     = var.project_tag
+    environment = var.environment_tag
+  }
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ---------------------------------------------------------------------------
+# DynamoDB Table — snapshot cache
+# ---------------------------------------------------------------------------
+# Tiny table by design: one item per snapshotted operation (~5 rows) plus a
+# LAST_RUN meta row. Generic pk/sk so a later per-resource layout (queryable
+# compliance rows, GSIs) can move in without a table migration.
+resource "aws_dynamodb_table" "tag_snapshots" {
+  name         = "${var.project_tag}-tag-compliance-snapshots"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+  range_key    = "sk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_tag}-tag-compliance-snapshots"
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Snapshot read grant for the TOOL Lambda
+# ---------------------------------------------------------------------------
+# The tool's own policy (lambda-tool-base) is a single Action/Resource
+# statement whose Resource must stay "*" for the scan APIs — it can't also
+# scope DDB to one table. Attach the narrowly-scoped read here instead.
+# No module cycle: this policy depends on the tool's ROLE, while the tool's
+# FUNCTION depends on this module's table name — distinct resources.
+resource "aws_iam_role_policy" "tool_snapshot_read" {
+  name = "${var.project_tag}-tag-governance-snapshot-read"
+  role = var.tool_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["dynamodb:GetItem"]
+      Resource = aws_dynamodb_table.tag_snapshots.arn
+    }]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Collector Lambda
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_log_group" "collector" {
+  name              = "/aws/lambda/${var.project_tag}-tag-governance-collector"
+  retention_in_days = var.log_retention_days
+  tags              = local.common_tags
+}
+
+resource "aws_iam_role" "collector" {
+  name = "${var.project_tag}-tag-governance-collector-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy" "collector" {
+  name = "${var.project_tag}-tag-governance-collector-policy"
+  role = aws_iam_role.collector.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # The collector's ONLY data-plane permissions: write snapshots, and
+        # invoke the tool Lambda that owns every AWS API the sweep needs.
+        # Deliberately NO resource-explorer / tagging / organizations perms
+        # here — one IAM surface (the tool's) for scan APIs.
+        Effect = "Allow"
+        Action = [
+          "dynamodb:PutItem",
+          "dynamodb:GetItem",
+        ]
+        Resource = aws_dynamodb_table.tag_snapshots.arn
+      },
+      {
+        # ARN constructed from the platform's deterministic tool naming
+        # (lambda-tool-base: "<project>-<tool>-tool") rather than passed as a
+        # module output — the tool module's env_vars reference THIS module's
+        # table_name, so an output-based reference here would be a cycle.
+        Effect   = "Allow"
+        Action   = ["lambda:InvokeFunction"]
+        Resource = "arn:aws:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:${var.tool_function_name}"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "collector" {
+  function_name    = "${var.project_tag}-tag-governance-collector"
+  role             = aws_iam_role.collector.arn
+  handler          = "handler.handler"
+  runtime          = "python3.12"
+  # The sweep serially invokes the tool for ~5 operations; check_tag_compliance
+  # against a large estate can run tens of seconds per call. 300s is generous
+  # headroom without allowing a runaway 15-min bill.
+  timeout          = 300
+  memory_size      = 256
+  filename         = var.collector_zip_path
+  source_code_hash = filebase64sha256(var.collector_zip_path)
+
+  environment {
+    variables = {
+      TAG_SNAPSHOT_TABLE_NAME = aws_dynamodb_table.tag_snapshots.name
+      TAG_TOOL_FUNCTION_NAME  = var.tool_function_name
+      SNAPSHOT_TTL_HOURS      = tostring(var.snapshot_ttl_hours)
+      LOG_LEVEL               = "INFO"
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.collector]
+
+  tags = local.common_tags
+}
+
+# ---------------------------------------------------------------------------
+# EventBridge schedule
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_event_rule" "schedule" {
+  name                = "${var.project_tag}-tag-governance-snapshot"
+  description         = "Periodic tag-compliance snapshot sweep"
+  schedule_expression = var.snapshot_schedule
+  tags                = local.common_tags
+}
+
+resource "aws_cloudwatch_event_target" "collector" {
+  rule = aws_cloudwatch_event_rule.schedule.name
+  arn  = aws_lambda_function.collector.arn
+}
+
+resource "aws_lambda_permission" "eventbridge" {
+  statement_id  = "AllowEventBridgeInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.collector.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.schedule.arn
+}

--- a/terraform/modules/custom/tag-governance-collection/outputs.tf
+++ b/terraform/modules/custom/tag-governance-collection/outputs.tf
@@ -1,0 +1,11 @@
+output "table_name" {
+  value = aws_dynamodb_table.tag_snapshots.name
+}
+
+output "table_arn" {
+  value = aws_dynamodb_table.tag_snapshots.arn
+}
+
+output "collector_function_name" {
+  value = aws_lambda_function.collector.function_name
+}

--- a/terraform/modules/custom/tag-governance-collection/variables.tf
+++ b/terraform/modules/custom/tag-governance-collection/variables.tf
@@ -1,0 +1,51 @@
+variable "project_tag" {
+  type = string
+}
+
+variable "environment_tag" {
+  type = string
+}
+
+variable "collector_zip_path" {
+  description = "Path to the collector Lambda zip file"
+  type        = string
+}
+
+variable "tool_function_name" {
+  description = "Name of the tag-governance MCP tool Lambda the collector invokes for scans"
+  type        = string
+}
+
+variable "tool_role_name" {
+  description = "Execution-role NAME of the tag-governance MCP tool Lambda — this module attaches the narrowly-scoped snapshot-table read grant to it"
+  type        = string
+}
+
+variable "snapshot_schedule" {
+  description = <<-EOT
+    EventBridge schedule expression for the compliance sweep. Default is every
+    6 hours — tag posture moves slowly, and each sweep costs a few tool-Lambda
+    invocations. Tighten (e.g. rate(1 hour)) if the org is actively remediating
+    and wants fresher numbers; users can always force a live scan per-request
+    with force_refresh=true.
+  EOT
+  type        = string
+  default     = "rate(6 hours)"
+}
+
+variable "snapshot_ttl_hours" {
+  description = <<-EOT
+    DynamoDB TTL on snapshot items, in hours. Acts as the staleness backstop:
+    if the collector stops running (schedule disabled, repeated failures), the
+    snapshot expires and the tool falls back to live queries rather than
+    serving unboundedly-old data. Keep comfortably above the schedule period —
+    default 48h vs the 6h schedule tolerates a weekend of failed runs.
+  EOT
+  type        = number
+  default     = 48
+}
+
+variable "log_retention_days" {
+  type    = number
+  default = 30
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -283,3 +283,22 @@ variable "memory_id" {
   type        = string
   default     = ""
 }
+
+variable "enable_tag_snapshots" {
+  description = <<-EOT
+    Deploy the tag-governance collection module: a scheduled Lambda that
+    snapshots org tag-compliance posture into DynamoDB so canonical
+    (unfiltered) tag-governance queries answer in milliseconds instead of a
+    3-60s live Resource Explorer sweep. Filtered queries and
+    force_refresh=true still go live. Only takes effect when the
+    tag-governance tool is deployed.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "tag_snapshot_schedule" {
+  description = "EventBridge schedule expression for the tag-compliance snapshot sweep."
+  type        = string
+  default     = "rate(6 hours)"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -4,9 +4,11 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      # >= 6.50.0: AGUI became a native server_protocol enum on
-      # aws_bedrockagentcore_agent_runtime. The supervisor's
-      # protocol_configuration relies on it.
+      # >= 6.50.0 is load-bearing for TWO aws_bedrockagentcore_agent_runtime
+      # features the supervisor relies on:
+      #   - AGUI as a native server_protocol enum (protocol_configuration)
+      #   - request_header_configuration (Authorization forwarding, which the
+      #     JWT-derived actor_id in agui_server.py depends on)
       version = ">= 6.50.0"
     }
   }

--- a/tests/unit/test_agui_report_streaming.py
+++ b/tests/unit/test_agui_report_streaming.py
@@ -582,3 +582,61 @@ class TestBuildFreeformTemplate:
         tpl = _build_freeform_template("Show me April spend!")
         # Cleaner sidebar rendering when the prompt ends in a sentence stop.
         assert tpl["name"] == "Show me April spend"
+
+
+# ---------------------------------------------------------------------------
+# actor_id derivation tests — the report-orphaning bug
+# ---------------------------------------------------------------------------
+
+
+def _jwt_with(claims: dict) -> str:
+    """Build an unsigned JWT-shaped token (header.payload.sig) for header tests.
+
+    The runtime's platform authorizer verifies signatures before requests reach
+    the container, so the container-side parser deliberately does not verify —
+    a structurally-valid token is all these tests need.
+    """
+    import base64 as b64
+
+    enc = lambda d: b64.urlsafe_b64encode(json.dumps(d).encode()).decode().rstrip("=")
+    return f"{enc({'alg': 'RS256'})}.{enc(claims)}.sig"
+
+
+class TestActorIdFromJwt:
+    def test_email_claim_wins_over_forwarded_props(self):
+        """The bug: a client-sent actor_id diverging from the JWT identity made
+        the report save under one partition key while core-api's poll (JWT-
+        derived) read another — the UI spun on 'Generating…' forever."""
+        from agents.shared.agui_server import _actor_id_from_jwt
+
+        req = MagicMock()
+        req.headers = {"authorization": f"Bearer {_jwt_with({'email': 'alice@example.com'})}"}
+        assert _actor_id_from_jwt(req) == "alice_at_example_com"
+
+    def test_sanitization_matches_core_api(self):
+        """Same input must produce core-api handler.py::_get_actor_id's output."""
+        from agents.shared.agui_server import _sanitize_actor_id
+
+        email = "first.last@sub.example.co.uk"
+        assert _sanitize_actor_id(email) == email.replace("@", "_at_").replace(".", "_")
+
+    def test_no_bearer_token_falls_back(self):
+        from agents.shared.agui_server import _actor_id_from_jwt
+
+        req = MagicMock()
+        req.headers = {}
+        assert _actor_id_from_jwt(req) == ""
+
+    def test_token_without_email_falls_back(self):
+        from agents.shared.agui_server import _actor_id_from_jwt
+
+        req = MagicMock()
+        req.headers = {"authorization": f"Bearer {_jwt_with({'sub': 'abc-123'})}"}
+        assert _actor_id_from_jwt(req) == ""
+
+    def test_malformed_token_falls_back_not_crashes(self):
+        from agents.shared.agui_server import _actor_id_from_jwt
+
+        req = MagicMock()
+        req.headers = {"authorization": "Bearer not.a.jwt"}
+        assert _actor_id_from_jwt(req) == ""

--- a/tests/unit/test_tag_governance_collector.py
+++ b/tests/unit/test_tag_governance_collector.py
@@ -1,0 +1,147 @@
+"""Unit tests for the tag-governance collector Lambda.
+
+The collector orchestrates: invoke the tag-governance TOOL Lambda for each
+canonical operation, shrink oversized responses, persist to DynamoDB. All
+AWS calls are mocked — these tests pin the orchestration contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_HANDLER_PATH = (
+    _REPO_ROOT / "src" / "lambda" / "collectors" / "tag-governance" / "handler.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "tag_governance_collector_handler", _HANDLER_PATH
+)
+collector = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(collector)
+
+
+@pytest.fixture()
+def env(monkeypatch):
+    monkeypatch.setattr(collector, "TABLE_NAME", "snap-table")
+    monkeypatch.setattr(collector, "TOOL_FUNCTION_NAME", "cloudops-tag-governance-tool")
+
+
+def _lambda_response(payload: dict, function_error: str | None = None):
+    body = MagicMock()
+    body.read.return_value = json.dumps(payload).encode()
+    resp = {"Payload": body}
+    if function_error:
+        resp["FunctionError"] = function_error
+    return resp
+
+
+class TestInvokeTool:
+    def test_sends_gateway_style_client_context(self, env, monkeypatch):
+        """The tool routes on bedrockAgentCoreToolName from ClientContext —
+        the collector must impersonate the gateway's naming exactly."""
+        import base64
+
+        lam = MagicMock()
+        lam.invoke.return_value = _lambda_response({"ok": True})
+        monkeypatch.setattr(collector, "_lambda_client", lambda: lam)
+
+        out = collector._invoke_tool("check_tag_compliance", {"max_resources": 1000})
+        assert out == {"ok": True}
+        ctx = json.loads(base64.b64decode(lam.invoke.call_args.kwargs["ClientContext"]))
+        assert (
+            ctx["custom"]["bedrockAgentCoreToolName"]
+            == "tag-governance___check_tag_compliance"
+        )
+
+    def test_function_error_raises(self, env, monkeypatch):
+        lam = MagicMock()
+        lam.invoke.return_value = _lambda_response({"errorMessage": "boom"}, "Unhandled")
+        monkeypatch.setattr(collector, "_lambda_client", lambda: lam)
+        with pytest.raises(RuntimeError, match="invoke failed"):
+            collector._invoke_tool("get_required_tags", {})
+
+
+class TestShrinkToFit:
+    def test_small_response_untouched(self):
+        resp, trimmed = collector._shrink_to_fit({"a": 1})
+        assert resp == {"a": 1} and trimmed is False
+
+    def test_oversized_detail_list_trimmed_counts_kept(self):
+        big = {
+            "non_compliant_count": 5000,
+            "non_compliant_resources": [
+                {"arn": "x" * 200, "violations": ["v"]} for _ in range(3000)
+            ],
+        }
+        resp, trimmed = collector._shrink_to_fit(big)
+        assert trimmed is True
+        assert resp["non_compliant_count"] == 5000  # counts never trimmed
+        assert len(resp["non_compliant_resources"]) < 3000
+        assert "snapshot_note" in resp
+        assert len(json.dumps(resp).encode()) <= collector._MAX_ITEM_BYTES
+
+
+class TestHandler:
+    def test_sweeps_all_canonical_ops_and_writes_meta(self, env, monkeypatch):
+        lam = MagicMock()
+        lam.invoke.return_value = _lambda_response({"ok": True})
+        ddb = MagicMock()
+        monkeypatch.setattr(collector, "_lambda_client", lambda: lam)
+        monkeypatch.setattr(collector, "_ddb", lambda: ddb)
+
+        result = collector.handler({}, None)
+
+        assert len(result["results"]) == len(collector.CANONICAL_OPS)
+        assert all(r.startswith("ok") for r in result["results"].values())
+        # one CACHE item per op + one META row
+        assert ddb.put_item.call_count == len(collector.CANONICAL_OPS) + 1
+        meta = ddb.put_item.call_args_list[-1].kwargs["Item"]
+        assert meta["pk"]["S"] == "META" and meta["sk"]["S"] == "LAST_RUN"
+
+    def test_one_failed_op_does_not_kill_the_sweep(self, env, monkeypatch):
+        """get_org_tag_compliance_summary legitimately fails without an
+        attached Tag Policy — the other snapshots must still be written."""
+        lam = MagicMock()
+
+        def _invoke(**kwargs):
+            import base64
+
+            ctx = json.loads(base64.b64decode(kwargs["ClientContext"]))
+            op = ctx["custom"]["bedrockAgentCoreToolName"].split("___")[1]
+            if op == "get_org_tag_compliance_summary":
+                raise RuntimeError("no policy")
+            return _lambda_response({"ok": op})
+
+        lam.invoke.side_effect = _invoke
+        ddb = MagicMock()
+        monkeypatch.setattr(collector, "_lambda_client", lambda: lam)
+        monkeypatch.setattr(collector, "_ddb", lambda: ddb)
+
+        result = collector.handler({}, None)
+        failed = [op for op, r in result["results"].items() if r.startswith("FAILED")]
+        assert failed == ["get_org_tag_compliance_summary"]
+        ok = [op for op, r in result["results"].items() if r.startswith("ok")]
+        assert len(ok) == len(collector.CANONICAL_OPS) - 1
+
+    def test_tool_error_payload_is_cached_distinctly(self, env, monkeypatch):
+        """An error RESPONSE (vs an invoke failure) is a valid snapshot — the
+        tool would return the same error live, just slower."""
+        lam = MagicMock()
+        lam.invoke.return_value = _lambda_response({"error": "No required-tag policy found"})
+        ddb = MagicMock()
+        monkeypatch.setattr(collector, "_lambda_client", lambda: lam)
+        monkeypatch.setattr(collector, "_ddb", lambda: ddb)
+
+        result = collector.handler({}, None)
+        assert all(r.startswith("error-cached") for r in result["results"].values())
+
+    def test_missing_env_raises(self, monkeypatch):
+        monkeypatch.setattr(collector, "TABLE_NAME", "")
+        with pytest.raises(RuntimeError, match="must be set"):
+            collector.handler({}, None)

--- a/tests/unit/test_tag_governance_tool.py
+++ b/tests/unit/test_tag_governance_tool.py
@@ -538,3 +538,86 @@ class TestGetRemediationGuidance:
         result = handler.handle_get_remediation_guidance({})
         assert result["links"] == []
         assert "compliant" in result["summary"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Snapshot cache (collector fast path)
+# ---------------------------------------------------------------------------
+
+class TestSnapshotLookup:
+    """_snapshot_lookup gates the DDB fast path written by the collector."""
+
+    def _with_table(self, monkeypatch, item=None, raises=None):
+        monkeypatch.setattr(handler, "_SNAPSHOT_TABLE", "snap-table")
+        ddb = MagicMock()
+        if raises:
+            ddb.get_item.side_effect = raises
+        else:
+            ddb.get_item.return_value = {"Item": item} if item else {}
+        monkeypatch.setattr(handler.boto3, "client", MagicMock(return_value=ddb))
+        return ddb
+
+    def _item(self, payload: dict, snapshot_at="2026-08-09T00:00:00+00:00"):
+        import json as _json
+        return {
+            "payload": {"S": _json.dumps(payload)},
+            "snapshot_at": {"S": snapshot_at},
+        }
+
+    def test_disabled_without_table_env(self, monkeypatch):
+        monkeypatch.setattr(handler, "_SNAPSHOT_TABLE", "")
+        assert handler._snapshot_lookup("check_tag_compliance", {}) is None
+
+    def test_canonical_query_served_from_snapshot(self, monkeypatch):
+        self._with_table(monkeypatch, self._item({"total_resources_scanned": 42}))
+        out = handler._snapshot_lookup("check_tag_compliance", {})
+        assert out["total_resources_scanned"] == 42
+        assert out["data_source"] == "scheduled_snapshot"
+        assert out["data_as_of"] == "2026-08-09T00:00:00+00:00"
+
+    def test_force_refresh_goes_live(self, monkeypatch):
+        ddb = self._with_table(monkeypatch, self._item({"x": 1}))
+        assert handler._snapshot_lookup("check_tag_compliance", {"force_refresh": True}) is None
+        ddb.get_item.assert_not_called()
+
+    def test_filtered_query_goes_live(self, monkeypatch):
+        """A snapshot computed for the canonical sweep can't answer a
+        resource_types-filtered question — must fall through to live."""
+        ddb = self._with_table(monkeypatch, self._item({"x": 1}))
+        out = handler._snapshot_lookup(
+            "check_tag_compliance", {"resource_types": ["ec2:instance"]}
+        )
+        assert out is None
+        ddb.get_item.assert_not_called()
+
+    def test_non_eligible_op_goes_live(self, monkeypatch):
+        self._with_table(monkeypatch, self._item({"x": 1}))
+        assert handler._snapshot_lookup("list_cost_allocation_tag_status", {}) is None
+
+    def test_cache_miss_goes_live(self, monkeypatch):
+        self._with_table(monkeypatch, item=None)
+        assert handler._snapshot_lookup("check_tag_compliance", {}) is None
+
+    def test_ddb_failure_falls_back_not_crashes(self, monkeypatch):
+        self._with_table(monkeypatch, raises=RuntimeError("ddb down"))
+        assert handler._snapshot_lookup("check_tag_compliance", {}) is None
+
+    def test_caller_max_resources_truncates_detail(self, monkeypatch):
+        payload = {
+            "non_compliant_count": 100,
+            "non_compliant_resources": [{"arn": f"a{i}"} for i in range(100)],
+        }
+        self._with_table(monkeypatch, self._item(payload))
+        out = handler._snapshot_lookup("check_tag_compliance", {"max_resources": 5})
+        assert len(out["non_compliant_resources"]) == 5
+        assert out["truncated"] is True
+        # counts are untouched — they were computed over the full scan
+        assert out["non_compliant_count"] == 100
+
+    def test_dispatcher_prefers_snapshot(self, monkeypatch):
+        self._with_table(monkeypatch, self._item({"answer": "cached"}))
+        live = MagicMock()
+        monkeypatch.setitem(handler._TOOL_HANDLERS, "check_tag_compliance", live)
+        out = handler.handler({}, _make_context("check_tag_compliance"))
+        assert out["answer"] == "cached"
+        live.assert_not_called()


### PR DESCRIPTION
Two changes from one investigation into slow tag reports that sometimes never appeared.
  
Scheduled compliance snapshots. Tag-governance was fully live-query: every canonical question re-ran a 3–60s Resource Explorer sweep, and report sections tripled it. A new scheduled collector (EventBridge → Lambda) runs the sweeps through the same tool Lambda — so live and cached logic can't drift — and stores responses in a TTL'd DynamoDB table; the tool serves canonical queries from the snapshot, tagged with data_as_of / data_source. Filtered queries, force_refresh=true, and cache misses fall through to the live path, so with the collector disabled the tool is unchanged. Detail lists trim to the DynamoDB 400KB item cap with counts computed over the full scan; the 48h TTL bounds staleness. Standalone module (modules/custom/tag-governance-collection), opt out with enable_tag_snapshots=false. Negligible cost — see docs/cost-estimate.md.

Report actor_id derivation. The report row was written under a client-supplied actor_id (forwardedProps) while the status poll used the JWT email claim — any divergence left the report complete in DynamoDB but the UI polling a different key, stuck on "Generating…". actor_id is now derived server-side from the validated JWT (matching core-api), with the client value only a tokenless fallback. The runtime strips client headers unless allowlisted, so the supervisor Terraform sets request_header_configuration = ["Authorization"] and both update_agent_runtime paths in sync.sh preserve it (the update is not partial).

Verified end-to-end on a deployed stack; 510 unit tests pass (22 new).